### PR TITLE
feat: add registration token management view

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -25,7 +25,7 @@ The project uses the standard .NET 10 CLI and Docker:
 - **UI/UX Design:** The interface should be modern, professional, and heavily focused on functionality and data density (as an internal admin tool). We will use **MudBlazor** for Material Design components (data grids, dialogs) instead of raw Bootstrap.
 
 ## Upcoming Task List
-- [ ] **Registration Tokens:** Build a view to manage and generate registration tokens.
+- [x] **Registration Tokens:** Build a view to manage and generate registration tokens.
 - [x] **Event Reports:** Implement a dashboard to review and act on reported events/messages.
 - [x] **Federation Destinations:** Create a view to check federation status and destination queues.
 - [x] **Server Notices:** Add functionality to broadcast server notices to users.

--- a/src/SynapseAdmin/Components/Layout/NavMenu.razor
+++ b/src/SynapseAdmin/Components/Layout/NavMenu.razor
@@ -5,6 +5,7 @@
     <MudNavLink Href="reports" Icon="@Icons.Material.Filled.Report">Event Reports</MudNavLink>
     <MudNavLink Href="federation" Icon="@Icons.Material.Filled.CloudSync">Federation</MudNavLink>
     <MudNavLink Href="notices" Icon="@Icons.Material.Filled.Announcement">Server Notices</MudNavLink>
+    <MudNavLink Href="tokens" Icon="@Icons.Material.Filled.Key">Registration Tokens</MudNavLink>
     
     <AuthorizeView>
         <Authorized>

--- a/src/SynapseAdmin/Components/Pages/RegistrationTokenDialog.razor
+++ b/src/SynapseAdmin/Components/Pages/RegistrationTokenDialog.razor
@@ -1,0 +1,107 @@
+@using SynapseAdmin.Services
+@using LibMatrix.Homeservers
+@using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Requests
+@using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses
+@using MudBlazor
+@inject MudBlazor.IDialogService DialogService
+@inject ISnackbar Snackbar
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.Key" Class="mr-3 mb-n1"/>
+            @if(IsEdit) {
+                <text>Edit Registration Token</text>
+            } else {
+                <text>Create Registration Token</text>
+            }
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudForm @ref="form" @bind-IsValid="@success">
+            @if(!IsEdit) {
+                <MudTextField @bind-Value="token" 
+                              Label="Token String (optional, leave empty to generate)" 
+                              Variant="Variant.Outlined" 
+                              Class="mb-4" />
+            }
+            <MudNumericField @bind-Value="usesAllowed" 
+                             Label="Uses Allowed (optional, empty for unlimited)" 
+                             Min="1" 
+                             Variant="Variant.Outlined" 
+                             Class="mb-4" />
+                             
+            <MudDatePicker @bind-Date="expiryDate" 
+                           Label="Expiry Date (optional)" 
+                           Variant="Variant.Outlined" 
+                           Class="mb-4" />
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit" Disabled="@(!success)">
+            @(IsEdit ? "Save" : "Create")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter]
+    public bool IsEdit { get; set; } = false;
+
+    [Parameter]
+    public string? ExistingToken { get; set; }
+
+    [Parameter]
+    public int? ExistingUsesAllowed { get; set; }
+
+    [Parameter]
+    public DateTime? ExistingExpiryDate { get; set; }
+
+    private MudForm? form;
+    private bool success = true;
+    
+    private string? token;
+    private int? usesAllowed;
+    private DateTime? expiryDate;
+
+    protected override void OnInitialized()
+    {
+        if (IsEdit)
+        {
+            token = ExistingToken;
+            usesAllowed = ExistingUsesAllowed;
+            expiryDate = ExistingExpiryDate;
+        }
+    }
+
+    private void Cancel()
+    {
+        MudDialog.Cancel();
+    }
+
+    private void Submit()
+    {
+        if (IsEdit)
+        {
+            var request = new SynapseAdminRegistrationTokenUpdateRequest
+            {
+                UsesAllowed = usesAllowed,
+                ExpiryTime = expiryDate.HasValue ? ((DateTimeOffset)expiryDate.Value).ToUnixTimeMilliseconds() : null
+            };
+            MudDialog.Close(DialogResult.Ok(request));
+        }
+        else
+        {
+            var request = new SynapseAdminRegistrationTokenCreateRequest
+            {
+                Token = string.IsNullOrWhiteSpace(token) ? null : token,
+                UsesAllowed = usesAllowed,
+                ExpiryTime = expiryDate.HasValue ? ((DateTimeOffset)expiryDate.Value).ToUnixTimeMilliseconds() : null
+            };
+            MudDialog.Close(DialogResult.Ok(request));
+        }
+    }
+}

--- a/src/SynapseAdmin/Components/Pages/RegistrationTokens.razor
+++ b/src/SynapseAdmin/Components/Pages/RegistrationTokens.razor
@@ -1,0 +1,172 @@
+@page "/tokens"
+@using SynapseAdmin.Services
+@using LibMatrix.Homeservers
+@using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Requests
+@using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses
+@using Microsoft.AspNetCore.Authorization
+@inject MatrixSessionService MatrixSession
+@inject NavigationManager Navigation
+@inject MudBlazor.IDialogService DialogService
+@inject ISnackbar Snackbar
+@attribute [Authorize]
+
+<PageTitle>Registration Tokens - SynapseAdmin.NET</PageTitle>
+
+<MudText Typo="Typo.h3" Class="mb-6">Registration Tokens</MudText>
+
+@if (MatrixSession.AuthenticatedHomeserver is not AuthenticatedHomeserverSynapse synapseAdmin)
+{
+    <MudAlert Severity="Severity.Error" Elevation="2" Class="mb-4">
+        Registration token management requires Synapse Admin API access.
+    </MudAlert>
+}
+else
+{
+    <MudToolBar Class="mb-4 px-0">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="OpenCreateDialog" StartIcon="@Icons.Material.Filled.Add">
+            Create Token
+        </MudButton>
+        <MudSpacer />
+        <MudButton Variant="Variant.Outlined" Color="Color.Secondary" OnClick="LoadTokens" StartIcon="@Icons.Material.Filled.Refresh">
+            Refresh
+        </MudButton>
+    </MudToolBar>
+
+    <MudTable Items="@tokens" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@isLoading" LoadingProgressColor="Color.Info" Elevation="3">
+        <HeaderContent>
+            <MudTh>Token</MudTh>
+            <MudTh>Uses (Used / Allowed)</MudTh>
+            <MudTh>Pending</MudTh>
+            <MudTh>Expiry Date</MudTh>
+            <MudTh>Actions</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Token"><MudText Typo="Typo.body2">@context.Token</MudText></MudTd>
+            <MudTd DataLabel="Uses">
+                @context.Completed / @(context.UsesAllowed.HasValue ? context.UsesAllowed.Value.ToString() : "Unlimited")
+            </MudTd>
+            <MudTd DataLabel="Pending">@context.Pending</MudTd>
+            <MudTd DataLabel="Expiry Date">
+                @(context.ExpiryTimeDateTime.HasValue ? context.ExpiryTimeDateTime.Value.ToString("g") : "Never")
+            </MudTd>
+            <MudTd DataLabel="Actions">
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" Color="Color.Info" OnClick="@(() => OpenEditDialog(context))" />
+                <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error" OnClick="@(() => DeleteToken(context.Token))" />
+            </MudTd>
+        </RowTemplate>
+        <NoRecordsContent>
+            <MudText>No registration tokens found.</MudText>
+        </NoRecordsContent>
+        <PagerContent>
+            <MudTablePager />
+        </PagerContent>
+    </MudTable>
+}
+
+@code {
+    private List<SynapseAdminRegistrationTokenListResult.SynapseAdminRegistrationTokenListResultToken> tokens = new();
+    private bool isLoading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadTokens();
+    }
+
+    private async Task LoadTokens()
+    {
+        if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+        {
+            isLoading = true;
+            try
+            {
+                tokens = await synapseAdmin.Admin.GetRegistrationTokensAsync();
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add($"Error loading tokens: {ex.Message}", Severity.Error);
+            }
+            finally
+            {
+                isLoading = false;
+            }
+        }
+    }
+
+    private async Task OpenCreateDialog()
+    {
+        var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<RegistrationTokenDialog>("Create Token", options);
+        var result = await dialog.Result;
+
+        if (result != null && !result.Canceled && result.Data is SynapseAdminRegistrationTokenCreateRequest request)
+        {
+            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            {
+                try
+                {
+                    await synapseAdmin.Admin.CreateRegistrationTokenAsync(request);
+                    Snackbar.Add("Token created successfully.", Severity.Success);
+                    await LoadTokens();
+                }
+                catch (Exception ex)
+                {
+                    Snackbar.Add($"Error creating token: {ex.Message}", Severity.Error);
+                }
+            }
+        }
+    }
+
+    private async Task OpenEditDialog(SynapseAdminRegistrationTokenListResult.SynapseAdminRegistrationTokenListResultToken tokenObj)
+    {
+        var parameters = new DialogParameters
+        {
+            { "IsEdit", true },
+            { "ExistingToken", tokenObj.Token },
+            { "ExistingUsesAllowed", tokenObj.UsesAllowed },
+            { "ExistingExpiryDate", tokenObj.ExpiryTimeDateTime }
+        };
+
+        var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<RegistrationTokenDialog>("Edit Token", parameters, options);
+        var result = await dialog.Result;
+
+        if (result != null && !result.Canceled && result.Data is SynapseAdminRegistrationTokenUpdateRequest request)
+        {
+            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            {
+                try
+                {
+                    await synapseAdmin.Admin.UpdateRegistrationTokenAsync(tokenObj.Token, request);
+                    Snackbar.Add("Token updated successfully.", Severity.Success);
+                    await LoadTokens();
+                }
+                catch (Exception ex)
+                {
+                    Snackbar.Add($"Error updating token: {ex.Message}", Severity.Error);
+                }
+            }
+        }
+    }
+
+    private async Task DeleteToken(string token)
+    {
+        bool? confirmed = await DialogService.ShowMessageBoxAsync(
+            "Delete Token",
+            $"Are you sure you want to delete the token '{token}'?",
+            yesText: "Delete", cancelText: "Cancel");
+
+        if (confirmed == true && MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+        {
+            try
+            {
+                await synapseAdmin.Admin.DeleteRegistrationTokenAsync(token);
+                Snackbar.Add("Token deleted successfully.", Severity.Success);
+                await LoadTokens();
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add($"Error deleting token: {ex.Message}", Severity.Error);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implemented a view to manage and generate registration tokens for the Synapse Matrix homeserver.

- Created RegistrationTokens component to list, refresh, and delete tokens.
- Created RegistrationTokenDialog to handle both token creation and updating.
- Added a new navigation link in NavMenu pointing to the tokens page.
- Marked the corresponding task as completed in GEMINI.md.