### PR TITLE
fix: resolve MudBlazor MUD0002 warning in UserDetails

### DIFF
--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor
@@ -39,7 +39,9 @@ else
                     <div class="d-flex align-center mb-4">
                         @if (!string.IsNullOrEmpty(userDetails.AvatarUrl))
                         {
-                            <MudAvatar Image="@(userDetails.AvatarUrl.StartsWith("mxc://") ? $"{MatrixSession.AuthenticatedHomeserver.WellKnownUris.Client}/_matrix/media/v3/download/{userDetails.AvatarUrl.Substring(6)}" : userDetails.AvatarUrl)" Size="Size.Large" Class="mr-4" />
+                            <MudAvatar Size="Size.Large" Class="mr-4">
+                                <MudImage Src="@(userDetails.AvatarUrl.StartsWith("mxc://") ? $"{MatrixSession.AuthenticatedHomeserver.WellKnownUris.Client}/_matrix/media/v3/download/{userDetails.AvatarUrl.Substring(6)}" : userDetails.AvatarUrl)" />
+                            </MudAvatar>
                         }
                         else
                         {


### PR DESCRIPTION
During a code review, it was identified that the `UserDetails.razor` component used the `Image` attribute on `MudAvatar`, which is illegal/deprecated in recent versions of MudBlazor and caused compiler warning `MUD0002`. 

This has been resolved by placing a `MudImage` component directly inside the `MudAvatar` per the latest MudBlazor documentation guidelines. No other significant security or style issues were found.