### PR TITLE
docs: add technology and status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # SynapseAdmin.NET
 
 ![AI Assisted](https://img.shields.io/badge/AI-Assisted-blue)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](./LICENSE)
+[![GitHub build status](https://img.shields.io/github/actions/workflow/status/benjamin-aicheler/SynapseAdmin.NET/dotnet.yml?branch=main)](https://github.com/benjamin-aicheler/SynapseAdmin.NET/actions)
+![.NET 10](https://img.shields.io/badge/.NET_10-512BD4?style=flat&logo=dotnet&logoColor=white)
+![Blazor](https://img.shields.io/badge/Blazor-512BD4?style=flat&logo=blazor&logoColor=white)
+![C#](https://img.shields.io/badge/C%23-239120?style=flat&logo=c-sharp&logoColor=white)
 
 A modern .NET 10 Blazor Server web application for administering Synapse (Matrix homeservers).
 


### PR DESCRIPTION
Added Shields.io badges for License, GitHub Actions build status, .NET 10, Blazor, and C# to the top of the README to showcase the technology stack and repository health at a glance.