### PR TITLE
docs: update LibMatrix and ArcaneLibs links to original repositories (fixes #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ SynapseAdmin.NET provides a comprehensive suite of tools to manage your Matrix h
 
 - **Framework:** .NET 10 Blazor Server (Interactive Server Mode)
 - **UI Component Library:** [MudBlazor](https://mudblazor.com/)
-- **Matrix SDK:** [LibMatrix](https://github.com/benjamin-aicheler/LibMatrix) (Git Submodule)
-- **Utilities:** [ArcaneLibs](https://github.com/benjamin-aicheler/ArcaneLibs) (Git Submodule)
+- **Matrix SDK:** [LibMatrix](https://github.com/Rory-LibMatrix/LibMatrix) (Git Submodule)
+- **Utilities:** [ArcaneLibs](https://github.com/TheArcaneBrony/ArcaneLibs) (Git Submodule)
 - **Deployment:** Docker & Docker Compose
 
 ## Getting Started

--- a/src/SynapseAdmin/Components/Pages/About.razor
+++ b/src/SynapseAdmin/Components/Pages/About.razor
@@ -18,10 +18,10 @@
                     <strong>Framework:</strong> .NET 10 Blazor Server
                 </MudListItem>
                 <MudListItem Icon="@Icons.Material.Filled.Code">
-                    <strong>SDK:</strong> <MudLink Href="https://github.com/benjamin-aicheler/LibMatrix" Target="_blank">LibMatrix</MudLink>
+                    <strong>SDK:</strong> <MudLink Href="https://github.com/Rory-LibMatrix/LibMatrix" Target="_blank">LibMatrix</MudLink>
                 </MudListItem>
                 <MudListItem Icon="@Icons.Material.Filled.Extension">
-                    <strong>Utilities:</strong> <MudLink Href="https://github.com/benjamin-aicheler/ArcaneLibs" Target="_blank">ArcaneLibs</MudLink>
+                    <strong>Utilities:</strong> <MudLink Href="https://github.com/TheArcaneBrony/ArcaneLibs" Target="_blank">ArcaneLibs</MudLink>
                 </MudListItem>
                 <MudListItem Icon="@Icons.Custom.Brands.GitHub">
                     <strong>Source Code:</strong> <MudLink Href="https://github.com/benjamin-aicheler/SynapseAdmin.NET" Target="_blank">GitHub Repository</MudLink>


### PR DESCRIPTION
## Summary
Updates the links for `LibMatrix` and `ArcaneLibs` to point to their original repositories.

## Related Issues
Closes #14

## Type of Change
- [ ] 🐛 Bugfix
- [ ] ✨ New Feature
- [ ] ♻️ Refactoring (no functional changes)
- [x] 📝 Documentation
- [ ] 🔧 Chore (Maintenance, CI/CD, Dependency updates)

## Changes Made
* Updated `LibMatrix` link in `README.md` and `About.razor` to `https://github.com/Rory-LibMatrix/LibMatrix`
* Updated `ArcaneLibs` link in `README.md` and `About.razor` to `https://github.com/TheArcaneBrony/ArcaneLibs`

## How to Test
1. Review the changes to ensure links are correctly updated.

## Pre-Merge Checklist
- [x] I have performed a self-review of my code
- [x] The project compiles without errors locally (`dotnet build`)
- [x] I have not committed any sensitive data (passwords, API keys)
- [x] The GitHub Actions CI pipeline (Status Checks) is expected to pass successfully
