### PR TITLE
feat: separate room deletion and blocking actions (fixes #15)

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -64,6 +64,7 @@ else
                 </MudCardHeader>
                 <MudCardContent>
                     <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="DeleteRoom" Class="mb-2 mr-2">Delete Room</MudButton>
+                    <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="DeleteAndBlockRoom" Class="mb-2 mr-2">Delete & Block Room</MudButton>
                     <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="BlockRoom" Class="mb-2 mr-2">Block Room</MudButton>
                     <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="QuarantineMedia" Class="mb-2">Quarantine Media</MudButton>
                 </MudCardContent>
@@ -168,8 +169,36 @@ else
         {
             bool? result = await DialogService.ShowMessageBoxAsync(
                 "Delete Room", 
-                "Are you sure you want to delete this room? This action cannot be undone.", 
-                yesText: "Delete!", cancelText: "Cancel");
+                "Are you sure you want to delete this room? This will NOT block it. This action cannot be undone.", 
+                yesText: "Delete", cancelText: "Cancel");
+            
+            if (result == true)
+            {
+                try {
+                    var req = new SynapseAdminRoomDeleteRequest
+                    {
+                        Block = false,
+                        Purge = true
+                    };
+                    await synapseAdmin.Admin.DeleteRoom(RoomId, req);
+                    Snackbar.Add("Room deletion initiated successfully.", Severity.Success);
+                }
+                catch (Exception ex)
+                {
+                    Snackbar.Add($"Error deleting room: {ex.Message}", Severity.Error);
+                }
+            }
+        }
+    }
+
+    private async Task DeleteAndBlockRoom()
+    {
+        if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+        {
+            bool? result = await DialogService.ShowMessageBoxAsync(
+                "Delete & Block Room", 
+                "Are you sure you want to delete AND block this room? This action cannot be undone.", 
+                yesText: "Delete & Block", cancelText: "Cancel");
             
             if (result == true)
             {
@@ -180,11 +209,11 @@ else
                         Purge = true
                     };
                     await synapseAdmin.Admin.DeleteRoom(RoomId, req);
-                    Snackbar.Add("Room deletion initiated successfully.", Severity.Success);
+                    Snackbar.Add("Room deletion and blocking initiated successfully.", Severity.Success);
                 }
                 catch (Exception ex)
                 {
-                    Snackbar.Add($"Error deleting room: {ex.Message}", Severity.Error);
+                    Snackbar.Add($"Error deleting and blocking room: {ex.Message}", Severity.Error);
                 }
             }
         }


### PR DESCRIPTION
## Summary
Decouples the "delete" and "block" actions for rooms, allowing administrators to delete a room without automatically blocking it. Adds a new dedicated "Delete & Block Room" action.

## Related Issues
Closes #15

## Type of Change
- [ ] 🐛 Bugfix
- [x] ✨ New Feature
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 📝 Documentation
- [ ] 🔧 Chore (Maintenance, CI/CD, Dependency updates)

## Changes Made
* Modified the existing `DeleteRoom` action in `RoomDetails.razor` to only purge the room (`Block = false`).
* Added a new `DeleteAndBlockRoom` action in `RoomDetails.razor` that purges and blocks the room (`Block = true`).
* Updated UI dialogs to clearly state the consequences of each action.

## How to Test
1. Build and run the application.
2. Navigate to a room's details page.
3. Verify there are now separate "Delete Room" and "Delete & Block Room" buttons.
4. Click "Delete Room" and verify the confirmation dialog mentions it will *not* block the room.
5. Click "Delete & Block Room" and verify the confirmation dialog mentions it *will* block the room.

## Pre-Merge Checklist
- [x] I have performed a self-review of my code
- [x] The project compiles without errors locally (`dotnet build`)
- [x] I have not committed any sensitive data (passwords, API keys)
- [x] The GitHub Actions CI pipeline (Status Checks) is expected to pass successfully