### PR TITLE
fix: add MudPopoverProvider to MainLayout

### DIFF
--- a/src/SynapseAdmin/Components/Layout/MainLayout.razor
+++ b/src/SynapseAdmin/Components/Layout/MainLayout.razor
@@ -3,6 +3,7 @@
 <MudThemeProvider @bind-IsDarkMode="@_isDarkMode" Theme="_theme" />
 <MudDialogProvider />
 <MudSnackbarProvider />
+<MudPopoverProvider />
 
 <MudRTLProvider RightToLeft="@_isRtl">
     <MudLayout>


### PR DESCRIPTION
Resolves #29 by adding the required `<MudPopoverProvider />` to `MainLayout.razor` so that MudBlazor components like dropdown menus work without throwing an `InvalidOperationException`.