### PR TITLE
Fix: culture change sends to login screen (#31)

### DIFF
--- a/src/SynapseAdmin/Components/App.razor
+++ b/src/SynapseAdmin/Components/App.razor
@@ -13,11 +13,11 @@
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <ImportMap />
     <link rel="icon" type="image/png" href="favicon.png" />
-    <HeadOutlet @rendermode="InteractiveServer" />
+    <HeadOutlet @rendermode="@(new InteractiveServerRenderMode(prerender: false))" />
 </head>
 
 <body>
-    <Routes @rendermode="InteractiveServer" />
+    <Routes @rendermode="@(new InteractiveServerRenderMode(prerender: false))" />
     <ReconnectModal />
     <script src="@Assets["_framework/blazor.web.js"]"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>

--- a/src/SynapseAdmin/Program.cs
+++ b/src/SynapseAdmin/Program.cs
@@ -62,6 +62,7 @@ app.UseAntiforgery();
 app.MapStaticAssets();
 app.MapControllers();
 app.MapRazorComponents<App>()
-    .AddInteractiveServerRenderMode();
+    .AddInteractiveServerRenderMode()
+    .AllowAnonymous();
 
 app.Run();


### PR DESCRIPTION
Disables prerendering in `App.razor` and adds `.AllowAnonymous()` to the Razor component endpoints in `Program.cs`. This ensures that the initial GET request (e.g., after a culture change redirect or manual refresh) can reach the server and start the Blazor circuit, allowing the `MatrixAuthenticationStateProvider` to correctly restore the session from local storage before the interactive authorization check is performed by the `AuthorizeRouteView`.