### PR TITLE
Fix: totals not showing on initial load (#36)

### DIFF
--- a/src/SynapseAdmin/Components/Pages/EventReports.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/EventReports.razor.cs
@@ -49,6 +49,7 @@ namespace SynapseAdmin.Components.Pages
                 if (result != null)
                 {
                     totalReports = result.Total;
+                    StateHasChanged();
                     return new TableData<SynapseAdminEventReportListResult.SynapseAdminEventReportListResultReport>() { TotalItems = result.Total, Items = result.Reports };
                 }
             }

--- a/src/SynapseAdmin/Components/Pages/FederationDestinations.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/FederationDestinations.razor.cs
@@ -44,6 +44,7 @@ namespace SynapseAdmin.Components.Pages
                     if (result != null)
                     {
                         totalDestinations = result.Total;
+                        StateHasChanged();
                         return new TableData<SynapseAdminDestinationListResult.SynapseAdminDestinationListResultDestination>() { TotalItems = result.Total, Items = result.Destinations };
                     }
                 }

--- a/src/SynapseAdmin/Components/Pages/Rooms.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/Rooms.razor.cs
@@ -44,6 +44,7 @@ namespace SynapseAdmin.Components.Pages
                     if (result != null)
                     {
                         totalRooms = result.TotalRooms;
+                        StateHasChanged();
                         return new TableData<SynapseAdminRoomListResult.SynapseAdminRoomListResultRoom>() { TotalItems = result.TotalRooms, Items = result.Rooms };
                     }
                 }

--- a/src/SynapseAdmin/Components/Pages/Users.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/Users.razor.cs
@@ -44,6 +44,7 @@ namespace SynapseAdmin.Components.Pages
                     if (result != null)
                     {
                         totalUsers = result.Total;
+                        StateHasChanged();
                         return new TableData<SynapseAdminUserListResult.SynapseAdminUserListResultUser>() { TotalItems = result.Total, Items = result.Users };
                     }
                 }


### PR DESCRIPTION
Ensures that `StateHasChanged()` is called after fetching data in `ServerReload` for Users and Rooms pages. This ensures the UI updates to show the total counts which are displayed outside the `MudTable` component. Resolves #36 