### PR TITLE
Feat: show room upgrade/tombstone info in room details (#32)

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -20,6 +20,19 @@ else if (roomDetails == null)
 }
 else
 {
+    @if (tombstone != null)
+    {
+        <MudAlert Severity="Severity.Warning" Variant="Variant.Filled" Class="mb-4">
+            @L["RoomUpgradedAlert"]
+            <MudButton Href="@($"/rooms/{Uri.EscapeDataString(tombstone.ReplacementRoom)}")"
+                       Variant="Variant.Text"
+                       Color="Color.Inherit"
+                       Class="ml-2">
+                @L["GoToReplacementRoom"]
+            </MudButton>
+        </MudAlert>
+    }
+
     <MudGrid>
         <MudItem xs="12" md="6">
             <MudCard Elevation="3">
@@ -35,6 +48,10 @@ else
                         <MudListItem T="string"><b>@L["Alias"]:</b> @roomDetails.CanonicalAlias</MudListItem>
                         <MudListItem T="string"><b>@L["Creator"]:</b> @roomDetails.Creator</MudListItem>
                         <MudListItem T="string"><b>@L["Version"]:</b> @roomDetails.Version</MudListItem>
+                        @if (tombstone != null)
+                        {
+                            <MudListItem T="string"><b>@L["ReplacementRoom"]:</b> <MudText Typo="Typo.caption" Style="word-break: break-all;">@tombstone.ReplacementRoom</MudText></MudListItem>
+                        }
                         <MudListItem T="string"><b>@L["Members"]:</b> @roomDetails.JoinedMembers (@L["Local"]: @roomDetails.JoinedLocalMembers)</MudListItem>
                         <MudListItem T="string"><b>@L["Public"]:</b> @roomDetails.Public</MudListItem>
                         <MudListItem T="string"><b>@L["JoinRules"]:</b> @roomDetails.JoinRules</MudListItem>

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
@@ -1,6 +1,7 @@
 using LibMatrix.Homeservers;
 using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Requests;
 using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
+using LibMatrix.EventTypes.Spec.State.RoomInfo;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
 using SynapseAdmin.Services;
@@ -24,8 +25,9 @@ namespace SynapseAdmin.Components.Pages
         private SynapseAdminRoomListResult.SynapseAdminRoomListResultRoom? roomDetails;
         private SynapseAdminRoomMemberListResult? members;
         private SynapseAdminRoomStateResult? stateEvents;
+        private RoomTombstoneEventContent? tombstone;
 
-        protected override async Task OnInitializedAsync()
+        protected override async Task OnParametersSetAsync()
         {
             await LoadRoomDetails();
         }
@@ -48,6 +50,10 @@ namespace SynapseAdmin.Components.Pages
                     
                     members = membersTask.Result;
                     stateEvents = stateTask.Result;
+
+                    tombstone = stateEvents?.Events
+                        .FirstOrDefault(x => x.Type == RoomTombstoneEventContent.EventId)?
+                        .ContentAs<RoomTombstoneEventContent>();
                 }
                 catch (Exception ex)
                 {

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -445,4 +445,16 @@
   <data name="RemoteNetworkNotice" xml:space="preserve">
     <value>Wenn Sie dieses Programm modifizieren, muss Ihre modifizierte Version allen Benutzern, die über ein Computernetzwerk aus der Ferne mit ihm interagieren, in prominenter Form die Gelegenheit bieten, den Quellcode Ihrer Version zu erhalten, indem Sie den Zugriff auf den Quellcode von einem Netzwerkserver aus kostenlos ermöglichen.</value>
   </data>
+  <data name="RoomUpgradedAlert" xml:space="preserve">
+    <value>Dieser Raum wurde aktualisiert.</value>
+  </data>
+  <data name="ReplacementRoom" xml:space="preserve">
+    <value>Ersatzraum</value>
+  </data>
+  <data name="GoToReplacementRoom" xml:space="preserve">
+    <value>Gehe zum Ersatzraum</value>
+  </data>
+  <data name="Tombstone" xml:space="preserve">
+    <value>Grabstein</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -445,4 +445,16 @@
   <data name="RemoteNetworkNotice" xml:space="preserve">
     <value>Si vous modifiez ce programme, votre version modifiée doit offrir de manière proéminente à tous les utilisateurs interagissant avec elle à distance via un réseau informatique une opportunité de recevoir le code source correspondant de votre version en fournissant l'accès au code source depuis un serveur réseau sans frais.</value>
   </data>
+  <data name="RoomUpgradedAlert" xml:space="preserve">
+    <value>Ce salon a été mis à niveau.</value>
+  </data>
+  <data name="ReplacementRoom" xml:space="preserve">
+    <value>Salon de remplacement</value>
+  </data>
+  <data name="GoToReplacementRoom" xml:space="preserve">
+    <value>Aller au salon de remplacement</value>
+  </data>
+  <data name="Tombstone" xml:space="preserve">
+    <value>Tombe</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -445,4 +445,16 @@
   <data name="RemoteNetworkNotice" xml:space="preserve">
     <value>If you modify this Program, your modified version must prominently offer all users interacting with it remotely through a computer network an opportunity to receive the Corresponding Source of your version by providing access to the Corresponding Source from a network server at no charge.</value>
   </data>
+  <data name="RoomUpgradedAlert" xml:space="preserve">
+    <value>This room has been upgraded.</value>
+  </data>
+  <data name="ReplacementRoom" xml:space="preserve">
+    <value>Replacement Room</value>
+  </data>
+  <data name="GoToReplacementRoom" xml:space="preserve">
+    <value>Go to Replacement Room</value>
+  </data>
+  <data name="Tombstone" xml:space="preserve">
+    <value>Tombstone</value>
+  </data>
 </root>


### PR DESCRIPTION
Detects if a room has been upgraded by looking for the `m.room.tombstone` state event. Displays a warning alert on the room details page with a link to the replacement room. Also adds the replacement room ID to the overview list. Includes translations for English, German, and French.