### PR TITLE
Refactor: Introduce RoomService (#39)

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
@@ -13,6 +13,8 @@ namespace SynapseAdmin.Components.Pages
         [Inject]
         public MatrixSessionService MatrixSession { get; set; } = null!;
         [Inject]
+        public RoomService RoomService { get; set; } = null!;
+        [Inject]
         public NavigationManager Navigation { get; set; } = null!;
         [Inject]
         public ISnackbar Snackbar { get; set; } = null!;
@@ -34,126 +36,93 @@ namespace SynapseAdmin.Components.Pages
 
         private async Task LoadRoomDetails()
         {
-            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            try
             {
-                try
+                var vm = await RoomService.GetRoomDetailsAsync(RoomId);
+                if (vm != null)
                 {
-                    // Note: Blazor unescapes parameters by default, so we may need to escape it again for the API call
-                    var encodedRoomId = Uri.EscapeDataString(RoomId);
-                    
-                    roomDetails = await synapseAdmin.ClientHttpClient.GetFromJsonAsync<SynapseAdminRoomListResult.SynapseAdminRoomListResultRoom>($"/_synapse/admin/v1/rooms/{encodedRoomId}");
-                    
-                    var membersTask = synapseAdmin.Admin.GetRoomMembersAsync(RoomId);
-                    var stateTask = synapseAdmin.Admin.GetRoomStateAsync(RoomId);
-                    
-                    await Task.WhenAll(membersTask, stateTask);
-                    
-                    members = membersTask.Result;
-                    stateEvents = stateTask.Result;
-
-                    tombstone = stateEvents?.Events
-                        .FirstOrDefault(x => x.Type == RoomTombstoneEventContent.EventId)?
-                        .ContentAs<RoomTombstoneEventContent>();
+                    roomDetails = vm.Details;
+                    members = vm.Members;
+                    stateEvents = vm.StateEvents;
+                    tombstone = vm.Tombstone;
                 }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Error fetching room details: {ex.Message}");
-                    Snackbar.Add($"Error fetching room details: {ex.Message}", Severity.Error);
-                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error fetching room details: {ex.Message}");
+                Snackbar.Add($"Error fetching room details: {ex.Message}", Severity.Error);
             }
         }
 
         private async Task DeleteRoom()
         {
-            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            bool? result = await DialogService.ShowMessageBoxAsync(
+                "Delete Room", 
+                "Are you sure you want to delete this room? This will NOT block it. This action cannot be undone.", 
+                yesText: "Delete", cancelText: "Cancel");
+            
+            if (result == true)
             {
-                bool? result = await DialogService.ShowMessageBoxAsync(
-                    "Delete Room", 
-                    "Are you sure you want to delete this room? This will NOT block it. This action cannot be undone.", 
-                    yesText: "Delete", cancelText: "Cancel");
-                
-                if (result == true)
+                try {
+                    await RoomService.DeleteRoomAsync(RoomId, block: false, purge: true);
+                    Snackbar.Add("Room deletion initiated successfully.", Severity.Success);
+                }
+                catch (Exception ex)
                 {
-                    try {
-                        var req = new SynapseAdminRoomDeleteRequest
-                        {
-                            Block = false,
-                            Purge = true
-                        };
-                        await synapseAdmin.Admin.DeleteRoom(RoomId, req);
-                        Snackbar.Add("Room deletion initiated successfully.", Severity.Success);
-                    }
-                    catch (Exception ex)
-                    {
-                        Snackbar.Add($"Error deleting room: {ex.Message}", Severity.Error);
-                    }
+                    Snackbar.Add($"Error deleting room: {ex.Message}", Severity.Error);
                 }
             }
         }
 
         private async Task DeleteAndBlockRoom()
         {
-            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            bool? result = await DialogService.ShowMessageBoxAsync(
+                "Delete & Block Room", 
+                "Are you sure you want to delete AND block this room? This action cannot be undone.", 
+                yesText: "Delete & Block", cancelText: "Cancel");
+            
+            if (result == true)
             {
-                bool? result = await DialogService.ShowMessageBoxAsync(
-                    "Delete & Block Room", 
-                    "Are you sure you want to delete AND block this room? This action cannot be undone.", 
-                    yesText: "Delete & Block", cancelText: "Cancel");
-                
-                if (result == true)
+                try {
+                    await RoomService.DeleteRoomAsync(RoomId, block: true, purge: true);
+                    Snackbar.Add("Room deletion and blocking initiated successfully.", Severity.Success);
+                }
+                catch (Exception ex)
                 {
-                    try {
-                        var req = new SynapseAdminRoomDeleteRequest
-                        {
-                            Block = true,
-                            Purge = true
-                        };
-                        await synapseAdmin.Admin.DeleteRoom(RoomId, req);
-                        Snackbar.Add("Room deletion and blocking initiated successfully.", Severity.Success);
-                    }
-                    catch (Exception ex)
-                    {
-                        Snackbar.Add($"Error deleting and blocking room: {ex.Message}", Severity.Error);
-                    }
+                    Snackbar.Add($"Error deleting and blocking room: {ex.Message}", Severity.Error);
                 }
             }
         }
 
         private async Task QuarantineMedia()
         {
-            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            bool? result = await DialogService.ShowMessageBoxAsync(
+                "Quarantine Media", 
+                "Are you sure you want to quarantine all media in this room?", 
+                yesText: "Quarantine", cancelText: "Cancel");
+            
+            if (result == true)
             {
-                bool? result = await DialogService.ShowMessageBoxAsync(
-                    "Quarantine Media", 
-                    "Are you sure you want to quarantine all media in this room?", 
-                    yesText: "Quarantine", cancelText: "Cancel");
-                
-                if (result == true)
+                try {
+                    await RoomService.QuarantineMediaAsync(RoomId);
+                    Snackbar.Add("Room media quarantined successfully.", Severity.Success);
+                }
+                catch (Exception ex)
                 {
-                    try {
-                        await synapseAdmin.Admin.QuarantineMediaByRoomId(RoomId);
-                        Snackbar.Add("Room media quarantined successfully.", Severity.Success);
-                    }
-                    catch (Exception ex)
-                    {
-                        Snackbar.Add($"Error quarantining media: {ex.Message}", Severity.Error);
-                    }
+                    Snackbar.Add($"Error quarantining media: {ex.Message}", Severity.Error);
                 }
             }
         }
 
         private async Task BlockRoom()
         {
-            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            try {
+                await RoomService.BlockRoomAsync(RoomId, true);
+                Snackbar.Add("Room blocked successfully.", Severity.Success);
+            }
+            catch (Exception ex)
             {
-                try {
-                    await synapseAdmin.Admin.BlockRoom(RoomId, true);
-                    Snackbar.Add("Room blocked successfully.", Severity.Success);
-                }
-                catch (Exception ex)
-                {
-                    Snackbar.Add($"Error blocking room: {ex.Message}", Severity.Error);
-                }
+                Snackbar.Add($"Error blocking room: {ex.Message}", Severity.Error);
             }
         }
     }

--- a/src/SynapseAdmin/Components/Pages/Rooms.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/Rooms.razor.cs
@@ -11,6 +11,8 @@ namespace SynapseAdmin.Components.Pages
         [Inject]
         public MatrixSessionService MatrixSession { get; set; } = null!;
         [Inject]
+        public RoomService RoomService { get; set; } = null!;
+        [Inject]
         public NavigationManager Navigation { get; set; } = null!;
         [Inject]
         public ISnackbar Snackbar { get; set; } = null!;
@@ -28,30 +30,20 @@ namespace SynapseAdmin.Components.Pages
 
         private async Task<TableData<SynapseAdminRoomListResult.SynapseAdminRoomListResultRoom>> ServerReload(TableState state, CancellationToken token)
         {
-            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            try
             {
-                try
-                {
-                    var offset = state.Page * state.PageSize;
-                    // Simple ordering support
-                    var orderBy = state.SortLabel ?? "name";
-                    var dir = state.SortDirection == SortDirection.Descending ? "b" : "f";
+                var offset = state.Page * state.PageSize;
+                var orderBy = state.SortLabel ?? "name";
 
-                    var url = $"/_synapse/admin/v1/rooms?from={offset}&limit={state.PageSize}&dir={dir}&order_by={orderBy}";
-
-                    var result = await synapseAdmin.ClientHttpClient.GetFromJsonAsync<SynapseAdminRoomListResult>(url, cancellationToken: token);
-                    
-                    if (result != null)
-                    {
-                        totalRooms = result.TotalRooms;
-                        StateHasChanged();
-                        return new TableData<SynapseAdminRoomListResult.SynapseAdminRoomListResultRoom>() { TotalItems = result.TotalRooms, Items = result.Rooms };
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Snackbar.Add($"Error fetching rooms: {ex.Message}", Severity.Error);
-                }
+                var (total, rooms) = await RoomService.GetRoomListAsync(offset, state.PageSize, orderBy, state.SortDirection, token: token);
+                
+                totalRooms = total;
+                StateHasChanged();
+                return new TableData<SynapseAdminRoomListResult.SynapseAdminRoomListResultRoom>() { TotalItems = total, Items = rooms };
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add($"Error fetching rooms: {ex.Message}", Severity.Error);
             }
 
             return new TableData<SynapseAdminRoomListResult.SynapseAdminRoomListResultRoom>() { TotalItems = 0, Items = new List<SynapseAdminRoomListResult.SynapseAdminRoomListResultRoom>() };

--- a/src/SynapseAdmin/Models/ViewModels/RoomDetailViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/RoomDetailViewModel.cs
@@ -1,0 +1,12 @@
+using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
+using LibMatrix.EventTypes.Spec.State.RoomInfo;
+
+namespace SynapseAdmin.Models.ViewModels;
+
+public class RoomDetailViewModel
+{
+    public SynapseAdminRoomListResult.SynapseAdminRoomListResultRoom Details { get; set; } = null!;
+    public SynapseAdminRoomMemberListResult? Members { get; set; }
+    public SynapseAdminRoomStateResult? StateEvents { get; set; }
+    public RoomTombstoneEventContent? Tombstone { get; set; }
+}

--- a/src/SynapseAdmin/Program.cs
+++ b/src/SynapseAdmin/Program.cs
@@ -24,6 +24,7 @@ builder.Services.AddLocalization();
 builder.Services.AddMudTranslations();
 
 builder.Services.AddScoped<MatrixSessionService>();
+builder.Services.AddScoped<RoomService>();
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddScoped<AuthenticationStateProvider, MatrixAuthenticationStateProvider>();
 builder.Services.AddScoped<MatrixAuthenticationStateProvider>(sp => (MatrixAuthenticationStateProvider)sp.GetRequiredService<AuthenticationStateProvider>());

--- a/src/SynapseAdmin/Services/RoomService.cs
+++ b/src/SynapseAdmin/Services/RoomService.cs
@@ -1,0 +1,83 @@
+using System.Net.Http.Json;
+using LibMatrix.Homeservers;
+using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
+using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Requests;
+using LibMatrix.EventTypes.Spec.State.RoomInfo;
+using SynapseAdmin.Models.ViewModels;
+using MudBlazor;
+
+namespace SynapseAdmin.Services;
+
+public class RoomService(MatrixSessionService sessionService)
+{
+    private AuthenticatedHomeserverSynapse? SynapseAdmin => sessionService.AuthenticatedHomeserver as AuthenticatedHomeserverSynapse;
+
+    public async Task<(int Total, List<SynapseAdminRoomListResult.SynapseAdminRoomListResultRoom> Rooms)> GetRoomListAsync(int offset, int limit, string orderBy, SortDirection direction, string? searchTerm = null, CancellationToken token = default)
+    {
+        if (SynapseAdmin == null) return (0, []);
+
+        var dir = direction == SortDirection.Descending ? "b" : "f";
+        var url = $"/_synapse/admin/v1/rooms?from={offset}&limit={limit}&dir={dir}&order_by={orderBy}";
+        if (!string.IsNullOrEmpty(searchTerm))
+        {
+            url += $"&search_term={Uri.EscapeDataString(searchTerm)}";
+        }
+
+        var result = await SynapseAdmin.ClientHttpClient.GetFromJsonAsync<SynapseAdminRoomListResult>(url, cancellationToken: token);
+        if (result == null) return (0, []);
+        
+        return (result.TotalRooms, result.Rooms);
+    }
+
+    public async Task<RoomDetailViewModel?> GetRoomDetailsAsync(string roomId)
+    {
+        if (SynapseAdmin == null) return null;
+
+        var encodedRoomId = Uri.EscapeDataString(roomId);
+        var roomDetails = await SynapseAdmin.ClientHttpClient.GetFromJsonAsync<SynapseAdminRoomListResult.SynapseAdminRoomListResultRoom>($"/_synapse/admin/v1/rooms/{encodedRoomId}");
+        
+        if (roomDetails == null) return null;
+
+        var membersTask = SynapseAdmin.Admin.GetRoomMembersAsync(roomId);
+        var stateTask = SynapseAdmin.Admin.GetRoomStateAsync(roomId);
+        
+        await Task.WhenAll(membersTask, stateTask);
+
+        var stateEvents = stateTask.Result;
+        var tombstone = stateEvents?.Events
+            .FirstOrDefault(x => x.Type == RoomTombstoneEventContent.EventId)?
+            .ContentAs<RoomTombstoneEventContent>();
+
+        return new RoomDetailViewModel
+        {
+            Details = roomDetails,
+            Members = membersTask.Result,
+            StateEvents = stateEvents,
+            Tombstone = tombstone
+        };
+    }
+
+    public async Task DeleteRoomAsync(string roomId, bool block = false, bool purge = true)
+    {
+        if (SynapseAdmin == null) return;
+
+        var req = new SynapseAdminRoomDeleteRequest
+        {
+            Block = block,
+            Purge = purge
+        };
+        await SynapseAdmin.Admin.DeleteRoom(roomId, req);
+    }
+
+    public async Task QuarantineMediaAsync(string roomId)
+    {
+        if (SynapseAdmin == null) return;
+        await SynapseAdmin.Admin.QuarantineMediaByRoomId(roomId);
+    }
+
+    public async Task BlockRoomAsync(string roomId, bool block)
+    {
+        if (SynapseAdmin == null) return;
+        await SynapseAdmin.Admin.BlockRoom(roomId, block);
+    }
+}


### PR DESCRIPTION
This PR introduces a Service Layer for room-related operations, moving logic out of Blazor components and into a dedicated `RoomService`.

### Changes:
- Created `RoomService` to handle room list fetching, details, deletion, and media quarantine.
- Created `RoomDetailViewModel` to encapsulate room details, members, state events, and tombstone info.
- Registered `RoomService` in Dependency Injection.
- Refactored `Rooms.razor.cs` and `RoomDetails.razor.cs` to use the new service.
- Improved code separation and maintainability.