### PR TITLE
Refactor: Introduce UserService (#39)

### DIFF
--- a/src/SynapseAdmin/Components/Pages/ServerNotices.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/ServerNotices.razor.cs
@@ -2,7 +2,6 @@ using LibMatrix.EventTypes.Spec;
 using LibMatrix.Homeservers;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
-using SynapseAdmin.Extensions;
 using SynapseAdmin.Services;
 
 namespace SynapseAdmin.Components.Pages
@@ -11,6 +10,8 @@ namespace SynapseAdmin.Components.Pages
     {
         [Inject]
         public MatrixSessionService MatrixSession { get; set; } = null!;
+        [Inject]
+        public UserService UserService { get; set; } = null!;
         [Inject]
         public NavigationManager Navigation { get; set; } = null!;
         [Inject]
@@ -25,36 +26,31 @@ namespace SynapseAdmin.Components.Pages
 
         private async Task SendNotice()
         {
-            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            isSending = true;
+            StateHasChanged();
+            
+            try
             {
-                isSending = true;
-                StateHasChanged();
+                await UserService.SendServerNoticeAsync(targetUserId, noticeMessage);
                 
-                try
+                Snackbar.Add("Server notice sent successfully!", Severity.Success);
+                
+                // Reset form
+                noticeMessage = string.Empty;
+                targetUserId = string.Empty;
+                if (form != null)
                 {
-                    var content = new RoomMessageEventContent(body: noticeMessage);
-                    
-                    await synapseAdmin.SendServerNoticeAsync(targetUserId, content);
-                    
-                    Snackbar.Add("Server notice sent successfully!", Severity.Success);
-                    
-                    // Reset form
-                    noticeMessage = string.Empty;
-                    targetUserId = string.Empty;
-                    if (form != null)
-                    {
-                        await form.ResetAsync();
-                    }
+                    await form.ResetAsync();
                 }
-                catch (Exception ex)
-                {
-                    Snackbar.Add($"Failed to send notice: {ex.Message}", Severity.Error);
-                }
-                finally
-                {
-                    isSending = false;
-                    StateHasChanged();
-                }
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add($"Failed to send notice: {ex.Message}", Severity.Error);
+            }
+            finally
+            {
+                isSending = false;
+                StateHasChanged();
             }
         }
     }

--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor.cs
@@ -11,6 +11,8 @@ namespace SynapseAdmin.Components.Pages
         [Inject]
         public MatrixSessionService MatrixSession { get; set; } = null!;
         [Inject]
+        public UserService UserService { get; set; } = null!;
+        [Inject]
         public NavigationManager Navigation { get; set; } = null!;
         [Inject]
         public ISnackbar Snackbar { get; set; } = null!;
@@ -30,88 +32,75 @@ namespace SynapseAdmin.Components.Pages
 
         private async Task LoadUserDetails()
         {
-            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            try
             {
-                try
+                var vm = await UserService.GetUserDetailsAsync(UserId);
+                if (vm != null)
                 {
-                    var encodedUserId = Uri.EscapeDataString(UserId);
-                    
-                    // Fetch user directly using HTTP Client since LibMatrix doesn't expose a GetUser yet
-                    userDetails = await synapseAdmin.ClientHttpClient.GetFromJsonAsync<SynapseAdminUserListResult.SynapseAdminUserListResultUser>($"/_synapse/admin/v2/users/{encodedUserId}");
-                    
-                    media = await synapseAdmin.Admin.GetUserMediaAsync(UserId);
+                    userDetails = vm.Details;
+                    media = vm.Media;
                 }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Error fetching user details: {ex.Message}");
-                    Snackbar.Add($"Error fetching user details: {ex.Message}", Severity.Error);
-                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error fetching user details: {ex.Message}");
+                Snackbar.Add($"Error fetching user details: {ex.Message}", Severity.Error);
             }
         }
 
         private async Task DeactivateUser()
         {
-            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            bool? result = await DialogService.ShowMessageBoxAsync(
+                "Deactivate User", 
+                "Are you sure you want to deactivate this user?", 
+                yesText: "Deactivate", cancelText: "Cancel");
+                
+            if (result == true)
             {
-                bool? result = await DialogService.ShowMessageBoxAsync(
-                    "Deactivate User", 
-                    "Are you sure you want to deactivate this user?", 
-                    yesText: "Deactivate", cancelText: "Cancel");
-                    
-                if (result == true)
+                try {
+                    await UserService.DeactivateUserAsync(UserId);
+                    Snackbar.Add("User deactivated.", Severity.Success);
+                    await LoadUserDetails();
+                }
+                catch (Exception ex)
                 {
-                    try {
-                        // Not fully mapped out in the LibMatrix SDK, simulating success
-                        var encodedUserId = Uri.EscapeDataString(UserId);
-                        var payload = new { erase = false };
-                        await synapseAdmin.ClientHttpClient.PostAsJsonAsync($"/_synapse/admin/v1/deactivate/{encodedUserId}", payload);
-                        Snackbar.Add("User deactivated.", Severity.Success);
-                        await LoadUserDetails();
-                    }
-                    catch (Exception ex)
-                    {
-                        Snackbar.Add($"Error deactivating user: {ex.Message}", Severity.Error);
-                    }
+                    Snackbar.Add($"Error deactivating user: {ex.Message}", Severity.Error);
                 }
             }
         }
 
         private async Task QuarantineAllMedia()
         {
-            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            bool? result = await DialogService.ShowMessageBoxAsync(
+                "Quarantine Media", 
+                "Are you sure you want to quarantine all media uploaded by this user?", 
+                yesText: "Quarantine", cancelText: "Cancel");
+            
+            if (result == true)
             {
-                bool? result = await DialogService.ShowMessageBoxAsync(
-                    "Quarantine Media", 
-                    "Are you sure you want to quarantine all media uploaded by this user?", 
-                    yesText: "Quarantine", cancelText: "Cancel");
-                
-                if (result == true)
+                try {
+                    await UserService.QuarantineMediaAsync(UserId);
+                    Snackbar.Add("User media quarantined successfully.", Severity.Success);
+                }
+                catch (Exception ex)
                 {
-                    try {
-                        await synapseAdmin.Admin.QuarantineMediaByUserId(UserId);
-                        Snackbar.Add("User media quarantined successfully.", Severity.Success);
-                    }
-                    catch (Exception ex)
-                    {
-                        Snackbar.Add($"Error quarantining media: {ex.Message}", Severity.Error);
-                    }
+                    Snackbar.Add($"Error quarantining media: {ex.Message}", Severity.Error);
                 }
             }
         }
 
         private async Task LoginAsUser()
         {
-            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
-            {
-                try {
-                    // Note: The login resp contains just an access token usually, need to pipe this securely
-                    var resp = await synapseAdmin.Admin.LoginUserAsync(UserId, TimeSpan.FromHours(1));
+            try {
+                var accessToken = await UserService.LoginAsUserAsync(UserId, TimeSpan.FromHours(1));
+                if (!string.IsNullOrEmpty(accessToken))
+                {
                     Snackbar.Add($"Login successful for 1 hour. Access Token retrieved. (Simulation)", Severity.Info);
                 }
-                catch (Exception ex)
-                {
-                    Snackbar.Add($"Error logging in as user: {ex.Message}", Severity.Error);
-                }
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add($"Error logging in as user: {ex.Message}", Severity.Error);
             }
         }
     }

--- a/src/SynapseAdmin/Components/Pages/Users.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/Users.razor.cs
@@ -11,6 +11,8 @@ namespace SynapseAdmin.Components.Pages
         [Inject]
         public MatrixSessionService MatrixSession { get; set; } = null!;
         [Inject]
+        public UserService UserService { get; set; } = null!;
+        [Inject]
         public NavigationManager Navigation { get; set; } = null!;
         [Inject]
         public ISnackbar Snackbar { get; set; } = null!;
@@ -28,30 +30,20 @@ namespace SynapseAdmin.Components.Pages
 
         private async Task<TableData<SynapseAdminUserListResult.SynapseAdminUserListResultUser>> ServerReload(TableState state, CancellationToken token)
         {
-            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            try
             {
-                try
-                {
-                    var offset = state.Page * state.PageSize;
-                    var orderBy = state.SortLabel ?? "name";
-                    var dir = state.SortDirection == SortDirection.Descending ? "b" : "f";
+                var offset = state.Page * state.PageSize;
+                var orderBy = state.SortLabel ?? "name";
 
-                    // Depending on the Synapse version, /_synapse/admin/v2/users supports offset/from.
-                    var url = $"/_synapse/admin/v2/users?from={offset}&limit={state.PageSize}&dir={dir}&order_by={orderBy}"; // we can also use search params
-
-                    var result = await synapseAdmin.ClientHttpClient.GetFromJsonAsync<SynapseAdminUserListResult>(url, cancellationToken: token);
-                    
-                    if (result != null)
-                    {
-                        totalUsers = result.Total;
-                        StateHasChanged();
-                        return new TableData<SynapseAdminUserListResult.SynapseAdminUserListResultUser>() { TotalItems = result.Total, Items = result.Users };
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Snackbar.Add($"Error fetching users: {ex.Message}", Severity.Error);
-                }
+                var (total, users) = await UserService.GetUserListAsync(offset, state.PageSize, orderBy, state.SortDirection, token: token);
+                
+                totalUsers = total;
+                StateHasChanged();
+                return new TableData<SynapseAdminUserListResult.SynapseAdminUserListResultUser>() { TotalItems = total, Items = users };
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add($"Error fetching users: {ex.Message}", Severity.Error);
             }
 
             return new TableData<SynapseAdminUserListResult.SynapseAdminUserListResultUser>() { TotalItems = 0, Items = new List<SynapseAdminUserListResult.SynapseAdminUserListResultUser>() };

--- a/src/SynapseAdmin/Models/ViewModels/UserDetailViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/UserDetailViewModel.cs
@@ -1,0 +1,9 @@
+using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
+
+namespace SynapseAdmin.Models.ViewModels;
+
+public class UserDetailViewModel
+{
+    public SynapseAdminUserListResult.SynapseAdminUserListResultUser Details { get; set; } = null!;
+    public SynapseAdminUserMediaResult? Media { get; set; }
+}

--- a/src/SynapseAdmin/Program.cs
+++ b/src/SynapseAdmin/Program.cs
@@ -25,6 +25,7 @@ builder.Services.AddMudTranslations();
 
 builder.Services.AddScoped<MatrixSessionService>();
 builder.Services.AddScoped<RoomService>();
+builder.Services.AddScoped<UserService>();
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddScoped<AuthenticationStateProvider, MatrixAuthenticationStateProvider>();
 builder.Services.AddScoped<MatrixAuthenticationStateProvider>(sp => (MatrixAuthenticationStateProvider)sp.GetRequiredService<AuthenticationStateProvider>());

--- a/src/SynapseAdmin/Services/UserService.cs
+++ b/src/SynapseAdmin/Services/UserService.cs
@@ -1,0 +1,75 @@
+using System.Net.Http.Json;
+using LibMatrix.Homeservers;
+using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
+using LibMatrix.EventTypes.Spec;
+using SynapseAdmin.Models.ViewModels;
+using SynapseAdmin.Extensions;
+using MudBlazor;
+
+namespace SynapseAdmin.Services;
+
+public class UserService(MatrixSessionService sessionService)
+{
+    private AuthenticatedHomeserverSynapse? SynapseAdmin => sessionService.AuthenticatedHomeserver as AuthenticatedHomeserverSynapse;
+
+    public async Task<(int Total, List<SynapseAdminUserListResult.SynapseAdminUserListResultUser> Users)> GetUserListAsync(int offset, int limit, string orderBy, SortDirection direction, CancellationToken token = default)
+    {
+        if (SynapseAdmin == null) return (0, []);
+
+        var dir = direction == SortDirection.Descending ? "b" : "f";
+        var url = $"/_synapse/admin/v2/users?from={offset}&limit={limit}&dir={dir}&order_by={orderBy}";
+
+        var result = await SynapseAdmin.ClientHttpClient.GetFromJsonAsync<SynapseAdminUserListResult>(url, cancellationToken: token);
+        if (result == null) return (0, []);
+        
+        return (result.Total, result.Users);
+    }
+
+    public async Task<UserDetailViewModel?> GetUserDetailsAsync(string userId)
+    {
+        if (SynapseAdmin == null) return null;
+
+        var encodedUserId = Uri.EscapeDataString(userId);
+        var userDetails = await SynapseAdmin.ClientHttpClient.GetFromJsonAsync<SynapseAdminUserListResult.SynapseAdminUserListResultUser>($"/_synapse/admin/v2/users/{encodedUserId}");
+        
+        if (userDetails == null) return null;
+
+        var media = await SynapseAdmin.Admin.GetUserMediaAsync(userId);
+
+        return new UserDetailViewModel
+        {
+            Details = userDetails,
+            Media = media
+        };
+    }
+
+    public async Task DeactivateUserAsync(string userId, bool erase = false)
+    {
+        if (SynapseAdmin == null) return;
+
+        var encodedUserId = Uri.EscapeDataString(userId);
+        var payload = new { erase };
+        await SynapseAdmin.ClientHttpClient.PostAsJsonAsync($"/_synapse/admin/v1/deactivate/{encodedUserId}", payload);
+    }
+
+    public async Task QuarantineMediaAsync(string userId)
+    {
+        if (SynapseAdmin == null) return;
+        await SynapseAdmin.Admin.QuarantineMediaByUserId(userId);
+    }
+
+    public async Task<string?> LoginAsUserAsync(string userId, TimeSpan expireIn)
+    {
+        if (SynapseAdmin == null) return null;
+        // The LibMatrix SDK call
+        var resp = await SynapseAdmin.Admin.LoginUserAsync(userId, expireIn);
+        return resp.AccessToken;
+    }
+
+    public async Task SendServerNoticeAsync(string userId, string message)
+    {
+        if (SynapseAdmin == null) return;
+        var content = new RoomMessageEventContent(body: message);
+        await SynapseAdmin.SendServerNoticeAsync(userId, content);
+    }
+}


### PR DESCRIPTION
This PR introduces the `UserService` as part of the N-Tier refactor. It follows the `RoomService` refactor and migrates user-related logic from components to the service layer.

### Changes:
- Created `UserService` and `UserDetailViewModel`.
- Refactored `Users.razor.cs`, `UserDetails.razor.cs`, and `ServerNotices.razor.cs`.
- Registered `UserService` in DI.