### PR TITLE
Refactor: Introduce EventReportService (#39)

### DIFF
--- a/src/SynapseAdmin/Components/Pages/EventReports.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/EventReports.razor.cs
@@ -12,6 +12,9 @@ namespace SynapseAdmin.Components.Pages
          public MatrixSessionService MatrixSession { get; set; } = null!;
 
          [Inject]
+         public EventReportService EventReportService { get; set; } = null!;
+
+         [Inject]
          public NavigationManager Navigation { get; set; } = null!;
 
          [Inject]
@@ -33,31 +36,20 @@ namespace SynapseAdmin.Components.Pages
 
     private async Task<TableData<SynapseAdminEventReportListResult.SynapseAdminEventReportListResultReport>> ServerReload(TableState state, CancellationToken token)
     {
-        if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+        try
         {
-            try
-            {
-                var offset = state.Page * state.PageSize;
-                
-                // Using dir for sorting because API allows it
-                var dir = state.SortDirection == SortDirection.Ascending ? "f" : "b";
+            var offset = state.Page * state.PageSize;
 
-                var url = $"/_synapse/admin/v1/event_reports?from={offset}&limit={state.PageSize}&dir={dir}";
-
-                var result = await synapseAdmin.ClientHttpClient.GetFromJsonAsync<SynapseAdminEventReportListResult>(url, cancellationToken: token);
-                
-                if (result != null)
-                {
-                    totalReports = result.Total;
-                    StateHasChanged();
-                    return new TableData<SynapseAdminEventReportListResult.SynapseAdminEventReportListResultReport>() { TotalItems = result.Total, Items = result.Reports };
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error fetching event reports: {ex.Message}");
-                Snackbar.Add($"Error fetching event reports: {ex.Message}", Severity.Error);
-            }
+            var (total, reports) = await EventReportService.GetEventReportsAsync(offset, state.PageSize, state.SortDirection, token: token);
+            
+            totalReports = total;
+            StateHasChanged();
+            return new TableData<SynapseAdminEventReportListResult.SynapseAdminEventReportListResultReport>() { TotalItems = total, Items = reports };
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error fetching event reports: {ex.Message}");
+            Snackbar.Add($"Error fetching event reports: {ex.Message}", Severity.Error);
         }
 
         return new TableData<SynapseAdminEventReportListResult.SynapseAdminEventReportListResultReport>() { TotalItems = 0, Items = new List<SynapseAdminEventReportListResult.SynapseAdminEventReportListResultReport>() };
@@ -65,25 +57,21 @@ namespace SynapseAdmin.Components.Pages
 
     private async Task DeleteReport(string reportId)
     {
-        if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+        bool? result = await DialogService.ShowMessageBoxAsync(
+            "Dismiss Report", 
+            "Are you sure you want to dismiss (delete) this report? The reported event will not be deleted from the room.", 
+            yesText: "Dismiss", cancelText: "Cancel");
+            
+        if (result == true)
         {
-            bool? result = await DialogService.ShowMessageBoxAsync(
-                "Dismiss Report", 
-                "Are you sure you want to dismiss (delete) this report? The reported event will not be deleted from the room.", 
-                yesText: "Dismiss", cancelText: "Cancel");
-                
-            if (result == true)
+            try {
+                await EventReportService.DeleteEventReportAsync(reportId);
+                Snackbar.Add("Report dismissed successfully.", Severity.Success);
+                await ReloadTable();
+            }
+            catch (Exception ex)
             {
-                try {
-                    // LibMatrix provides DeleteEventReportAsync
-                    await synapseAdmin.Admin.DeleteEventReportAsync(reportId);
-                    Snackbar.Add("Report dismissed successfully.", Severity.Success);
-                    await ReloadTable();
-                }
-                catch (Exception ex)
-                {
-                    Snackbar.Add($"Error dismissing report: {ex.Message}", Severity.Error);
-                }
+                Snackbar.Add($"Error dismissing report: {ex.Message}", Severity.Error);
             }
         }
     }

--- a/src/SynapseAdmin/Program.cs
+++ b/src/SynapseAdmin/Program.cs
@@ -27,6 +27,7 @@ builder.Services.AddScoped<MatrixSessionService>();
 builder.Services.AddScoped<RoomService>();
 builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<FederationService>();
+builder.Services.AddScoped<EventReportService>();
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddScoped<AuthenticationStateProvider, MatrixAuthenticationStateProvider>();
 builder.Services.AddScoped<MatrixAuthenticationStateProvider>(sp => (MatrixAuthenticationStateProvider)sp.GetRequiredService<AuthenticationStateProvider>());

--- a/src/SynapseAdmin/Services/EventReportService.cs
+++ b/src/SynapseAdmin/Services/EventReportService.cs
@@ -1,0 +1,30 @@
+using System.Net.Http.Json;
+using LibMatrix.Homeservers;
+using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
+using MudBlazor;
+
+namespace SynapseAdmin.Services;
+
+public class EventReportService(MatrixSessionService sessionService)
+{
+    private AuthenticatedHomeserverSynapse? SynapseAdmin => sessionService.AuthenticatedHomeserver as AuthenticatedHomeserverSynapse;
+
+    public async Task<(int Total, List<SynapseAdminEventReportListResult.SynapseAdminEventReportListResultReport> Reports)> GetEventReportsAsync(int offset, int limit, SortDirection direction, CancellationToken token = default)
+    {
+        if (SynapseAdmin == null) return (0, []);
+
+        var dir = direction == SortDirection.Ascending ? "f" : "b";
+        var url = $"/_synapse/admin/v1/event_reports?from={offset}&limit={limit}&dir={dir}";
+
+        var result = await SynapseAdmin.ClientHttpClient.GetFromJsonAsync<SynapseAdminEventReportListResult>(url, cancellationToken: token);
+        if (result == null) return (0, []);
+        
+        return (result.Total, result.Reports);
+    }
+
+    public async Task DeleteEventReportAsync(string reportId)
+    {
+        if (SynapseAdmin == null) return;
+        await SynapseAdmin.Admin.DeleteEventReportAsync(reportId);
+    }
+}


### PR DESCRIPTION
This PR introduces the `EventReportService` as part of the N-Tier refactor.

### Changes:
- Created `EventReportService` to handle fetching and dismissing event reports.
- Refactored `EventReports.razor.cs` to use the service instead of calling the SDK directly.
- Registered `EventReportService` in Dependency Injection.