### PR TITLE
Refactor: Introduce RegistrationTokenService (#39)

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RegistrationTokens.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RegistrationTokens.razor.cs
@@ -1,5 +1,6 @@
 using LibMatrix.Homeservers;
 using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
+using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Requests;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
 using SynapseAdmin.Services;
@@ -10,6 +11,8 @@ namespace SynapseAdmin.Components.Pages
     {
         [Inject] 
         public MatrixSessionService MatrixSession { get; set; } = null!;
+        [Inject] 
+        public RegistrationTokenService RegistrationTokenService { get; set; } = null!;
         [Inject] 
         public NavigationManager Navigation { get; set; } = null!;
         [Inject] 
@@ -27,21 +30,18 @@ namespace SynapseAdmin.Components.Pages
 
         private async Task LoadTokens()
         {
-            if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            isLoading = true;
+            try
             {
-                isLoading = true;
-                try
-                {
-                    tokens = await synapseAdmin.Admin.GetRegistrationTokensAsync();
-                }
-                catch (Exception ex)
-                {
-                    Snackbar.Add($"Error loading tokens: {ex.Message}", Severity.Error);
-                }
-                finally
-                {
-                    isLoading = false;
-                }
+                tokens = await RegistrationTokenService.GetRegistrationTokensAsync();
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add($"Error loading tokens: {ex.Message}", Severity.Error);
+            }
+            finally
+            {
+                isLoading = false;
             }
         }
 
@@ -53,18 +53,15 @@ namespace SynapseAdmin.Components.Pages
 
             if (result != null && !result.Canceled && result.Data is SynapseAdminRegistrationTokenCreateRequest request)
             {
-                if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+                try
                 {
-                    try
-                    {
-                        await synapseAdmin.Admin.CreateRegistrationTokenAsync(request);
-                        Snackbar.Add("Token created successfully.", Severity.Success);
-                        await LoadTokens();
-                    }
-                    catch (Exception ex)
-                    {
-                        Snackbar.Add($"Error creating token: {ex.Message}", Severity.Error);
-                    }
+                    await RegistrationTokenService.CreateRegistrationTokenAsync(request);
+                    Snackbar.Add("Token created successfully.", Severity.Success);
+                    await LoadTokens();
+                }
+                catch (Exception ex)
+                {
+                    Snackbar.Add($"Error creating token: {ex.Message}", Severity.Error);
                 }
             }
         }
@@ -85,18 +82,15 @@ namespace SynapseAdmin.Components.Pages
 
             if (result != null && !result.Canceled && result.Data is SynapseAdminRegistrationTokenUpdateRequest request)
             {
-                if (MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+                try
                 {
-                    try
-                    {
-                        await synapseAdmin.Admin.UpdateRegistrationTokenAsync(tokenObj.Token, request);
-                        Snackbar.Add("Token updated successfully.", Severity.Success);
-                        await LoadTokens();
-                    }
-                    catch (Exception ex)
-                    {
-                        Snackbar.Add($"Error updating token: {ex.Message}", Severity.Error);
-                    }
+                    await RegistrationTokenService.UpdateRegistrationTokenAsync(tokenObj.Token, request);
+                    Snackbar.Add("Token updated successfully.", Severity.Success);
+                    await LoadTokens();
+                }
+                catch (Exception ex)
+                {
+                    Snackbar.Add($"Error updating token: {ex.Message}", Severity.Error);
                 }
             }
         }
@@ -108,11 +102,11 @@ namespace SynapseAdmin.Components.Pages
                 $"Are you sure you want to delete the token '{token}'?",
                 yesText: "Delete", cancelText: "Cancel");
 
-            if (confirmed == true && MatrixSession.AuthenticatedHomeserver is AuthenticatedHomeserverSynapse synapseAdmin)
+            if (confirmed == true)
             {
                 try
                 {
-                    await synapseAdmin.Admin.DeleteRegistrationTokenAsync(token);
+                    await RegistrationTokenService.DeleteRegistrationTokenAsync(token);
                     Snackbar.Add("Token deleted successfully.", Severity.Success);
                     await LoadTokens();
                 }

--- a/src/SynapseAdmin/Program.cs
+++ b/src/SynapseAdmin/Program.cs
@@ -28,6 +28,7 @@ builder.Services.AddScoped<RoomService>();
 builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<FederationService>();
 builder.Services.AddScoped<EventReportService>();
+builder.Services.AddScoped<RegistrationTokenService>();
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddScoped<AuthenticationStateProvider, MatrixAuthenticationStateProvider>();
 builder.Services.AddScoped<MatrixAuthenticationStateProvider>(sp => (MatrixAuthenticationStateProvider)sp.GetRequiredService<AuthenticationStateProvider>());

--- a/src/SynapseAdmin/Services/RegistrationTokenService.cs
+++ b/src/SynapseAdmin/Services/RegistrationTokenService.cs
@@ -1,0 +1,34 @@
+using LibMatrix.Homeservers;
+using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
+using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Requests;
+
+namespace SynapseAdmin.Services;
+
+public class RegistrationTokenService(MatrixSessionService sessionService)
+{
+    private AuthenticatedHomeserverSynapse? SynapseAdmin => sessionService.AuthenticatedHomeserver as AuthenticatedHomeserverSynapse;
+
+    public async Task<List<SynapseAdminRegistrationTokenListResult.SynapseAdminRegistrationTokenListResultToken>> GetRegistrationTokensAsync()
+    {
+        if (SynapseAdmin == null) return [];
+        return await SynapseAdmin.Admin.GetRegistrationTokensAsync();
+    }
+
+    public async Task CreateRegistrationTokenAsync(SynapseAdminRegistrationTokenCreateRequest request)
+    {
+        if (SynapseAdmin == null) return;
+        await SynapseAdmin.Admin.CreateRegistrationTokenAsync(request);
+    }
+
+    public async Task UpdateRegistrationTokenAsync(string token, SynapseAdminRegistrationTokenUpdateRequest request)
+    {
+        if (SynapseAdmin == null) return;
+        await SynapseAdmin.Admin.UpdateRegistrationTokenAsync(token, request);
+    }
+
+    public async Task DeleteRegistrationTokenAsync(string token)
+    {
+        if (SynapseAdmin == null) return;
+        await SynapseAdmin.Admin.DeleteRegistrationTokenAsync(token);
+    }
+}


### PR DESCRIPTION
This PR introduces the `RegistrationTokenService` as part of the N-Tier refactor.

### Changes:
- Created `RegistrationTokenService` to handle registration token management.
- Refactored `RegistrationTokens.razor.cs` to use the new service.
- Registered `RegistrationTokenService` in DI.