### PR TITLE
fix: localize all confirmation dialogs and refine localization rule

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -27,9 +27,9 @@ The project uses the standard .NET 10 CLI and Docker:
 - **Interfaces:** ALWAYS extract an Interface (in `src/SynapseAdmin/Interfaces/`) for every service to enable unit testing, mocking, and decoupling.
 - **Error Handling:** Standardize all service methods to return `OperationResult` or `OperationResult<T>`. This forces the UI to handle success/failure explicitly.
 - **Localization Rule:** 
-    - **Services:** Responsible for generating localized, user-friendly messages for their operations using `IStringLocalizer`.
-    - **Code-Behind (.razor.cs):** Should NEVER perform translations for service actions. They simply consume and display the `Message` and `Severity` provided by the `OperationResult`.
-    - **Razor (.razor):** May use `IStringLocalizer` for static layout strings (labels, headers, button text).
+    - **Services:** Responsible for generating localized, user-friendly messages for **Business Outcomes** (the result of a protocol or data operation) using `IStringLocalizer`.
+    - **Code-Behind (.razor.cs):** Allowed to inject `IStringLocalizer` ONLY for **Interaction Logic** (e.g., Dialog titles/messages, complex UI-only alerts, or dynamic Page Titles). They should NEVER perform translations for service-level business logic.
+    - **Razor (.razor):** Uses `IStringLocalizer` for **Static Layout** strings (labels, headers, constant button text).
 - **Logging:** ALWAYS inject `ILogger<T>` into services and log exceptions/errors to provide server-side traceability for Matrix API failures.
 - **ViewModels:** Always use dedicated ViewModels (`src/SynapseAdmin/Models/ViewModels/`) to pass data from services to components. Avoid passing raw SDK models to the UI.
 - **Dependency Injection:** Services are registered in `Program.cs` and injected into components using the `[Inject]` attribute.

--- a/src/SynapseAdmin/Components/Pages/EventReports.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/EventReports.razor.cs
@@ -58,9 +58,9 @@ namespace SynapseAdmin.Components.Pages
         private async Task DeleteReport(string reportId)
         {
             bool? confirmed = await DialogService.ShowMessageBoxAsync(
-                "Dismiss Report", 
-                "Are you sure you want to dismiss (delete) this report? The reported event will not be deleted from the room.", 
-                yesText: "Dismiss", cancelText: "Cancel");
+                L["DismissReportTitle"], 
+                L["DismissReportConfirmation"], 
+                yesText: L["Dismiss"], cancelText: L["Cancel"]);
                 
             if (confirmed == true)
             {

--- a/src/SynapseAdmin/Components/Pages/FederationDestinations.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/FederationDestinations.razor.cs
@@ -56,9 +56,9 @@ namespace SynapseAdmin.Components.Pages
         private async Task ResetConnection(string destination)
         {
             bool? confirmed = await DialogService.ShowMessageBoxAsync(
-                "Reset Connection", 
-                $"Are you sure you want to reset the federation connection backoff for {destination}?", 
-                yesText: "Reset", cancelText: "Cancel");
+                L["ResetConnectionTitle"], 
+                string.Format(L["ResetConnectionConfirmation"], destination), 
+                yesText: L["Reset"], cancelText: L["Cancel"]);
                 
             if (confirmed == true)
             {

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
@@ -49,9 +49,9 @@ namespace SynapseAdmin.Components.Pages
         private async Task DeleteRoom()
         {
             bool? confirmed = await DialogService.ShowMessageBoxAsync(
-                "Delete Room", 
-                "Are you sure you want to delete this room? This will NOT block it. This action cannot be undone.", 
-                yesText: "Delete", cancelText: "Cancel");
+                L["DeleteRoomTitle"], 
+                L["DeleteRoomConfirmation"], 
+                yesText: L["Delete"], cancelText: L["Cancel"]);
             
             if (confirmed == true)
             {
@@ -63,9 +63,9 @@ namespace SynapseAdmin.Components.Pages
         private async Task DeleteAndBlockRoom()
         {
             bool? confirmed = await DialogService.ShowMessageBoxAsync(
-                "Delete & Block Room", 
-                "Are you sure you want to delete AND block this room? This action cannot be undone.", 
-                yesText: "Delete & Block", cancelText: "Cancel");
+                L["DeleteAndBlockRoomTitle"], 
+                L["DeleteAndBlockRoomConfirmation"], 
+                yesText: L["DeleteAndBlock"], cancelText: L["Cancel"]);
             
             if (confirmed == true)
             {
@@ -77,9 +77,9 @@ namespace SynapseAdmin.Components.Pages
         private async Task QuarantineMedia()
         {
             bool? confirmed = await DialogService.ShowMessageBoxAsync(
-                "Quarantine Media", 
-                "Are you sure you want to quarantine all media in this room?", 
-                yesText: "Quarantine", cancelText: "Cancel");
+                L["QuarantineMediaTitle"], 
+                L["QuarantineRoomMediaConfirmation"], 
+                yesText: L["Quarantine"], cancelText: L["Cancel"]);
             
             if (confirmed == true)
             {

--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor.cs
@@ -47,9 +47,9 @@ namespace SynapseAdmin.Components.Pages
         private async Task DeactivateUser()
         {
             bool? confirmed = await DialogService.ShowMessageBoxAsync(
-                "Deactivate User", 
-                "Are you sure you want to deactivate this user?", 
-                yesText: "Deactivate", cancelText: "Cancel");
+                L["DeactivateUserTitle"], 
+                L["DeactivateUserConfirmation"], 
+                yesText: L["Deactivate"], cancelText: L["Cancel"]);
                 
             if (confirmed == true)
             {
@@ -65,9 +65,9 @@ namespace SynapseAdmin.Components.Pages
         private async Task QuarantineAllMedia()
         {
             bool? confirmed = await DialogService.ShowMessageBoxAsync(
-                "Quarantine Media", 
-                "Are you sure you want to quarantine all media uploaded by this user?", 
-                yesText: "Quarantine", cancelText: "Cancel");
+                L["QuarantineMediaTitle"], 
+                L["QuarantineUserMediaConfirmation"], 
+                yesText: L["Quarantine"], cancelText: L["Cancel"]);
             
             if (confirmed == true)
             {

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -604,4 +604,55 @@
   <data name="ErrorDeletingEventReport" xml:space="preserve">
     <value>Fehler beim Löschen des Ereignisberichts {0}: {1}</value>
   </data>
+  <data name="ResetConnectionTitle" xml:space="preserve">
+    <value>Verbindung zurücksetzen</value>
+  </data>
+  <data name="ResetConnectionConfirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie den Föderationsverbindungs-Backoff für {0} zurücksetzen möchten?</value>
+  </data>
+  <data name="Reset" xml:space="preserve">
+    <value>Zurücksetzen</value>
+  </data>
+  <data name="DismissReportTitle" xml:space="preserve">
+    <value>Bericht verwerfen</value>
+  </data>
+  <data name="DismissReportConfirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie diesen Bericht verwerfen (löschen) möchten? Das gemeldete Ereignis wird nicht aus dem Raum gelöscht.</value>
+  </data>
+  <data name="DeleteRoomTitle" xml:space="preserve">
+    <value>Raum löschen</value>
+  </data>
+  <data name="DeleteRoomConfirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie diesen Raum löschen möchten? Dies wird ihn NICHT sperren. Diese Aktion kann nicht rückgängig gemacht werden.</value>
+  </data>
+  <data name="DeleteAndBlockRoomTitle" xml:space="preserve">
+    <value>Raum löschen &amp; sperren</value>
+  </data>
+  <data name="DeleteAndBlockRoomConfirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie diesen Raum löschen UND sperren möchten? Diese Aktion kann nicht rückgängig gemacht werden.</value>
+  </data>
+  <data name="DeleteAndBlock" xml:space="preserve">
+    <value>Löschen &amp; Sperren</value>
+  </data>
+  <data name="QuarantineMediaTitle" xml:space="preserve">
+    <value>Medien unter Quarantäne stellen</value>
+  </data>
+  <data name="QuarantineRoomMediaConfirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie alle Medien in diesem Raum unter Quarantäne stellen möchten?</value>
+  </data>
+  <data name="Quarantine" xml:space="preserve">
+    <value>Quarantäne</value>
+  </data>
+  <data name="DeactivateUserTitle" xml:space="preserve">
+    <value>Benutzer deaktivieren</value>
+  </data>
+  <data name="DeactivateUserConfirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie diesen Benutzer deaktivieren möchten?</value>
+  </data>
+  <data name="Deactivate" xml:space="preserve">
+    <value>Deaktivieren</value>
+  </data>
+  <data name="QuarantineUserMediaConfirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie alle von diesem Benutzer hochgeladenen Medien unter Quarantäne stellen möchten?</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -604,4 +604,55 @@
   <data name="ErrorDeletingEventReport" xml:space="preserve">
     <value>Erreur lors de la suppression du rapport d'événement {0} : {1}</value>
   </data>
+  <data name="ResetConnectionTitle" xml:space="preserve">
+    <value>Réinitialiser la connexion</value>
+  </data>
+  <data name="ResetConnectionConfirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir réinitialiser le délai de connexion de fédération pour {0} ?</value>
+  </data>
+  <data name="Reset" xml:space="preserve">
+    <value>Réinitialiser</value>
+  </data>
+  <data name="DismissReportTitle" xml:space="preserve">
+    <value>Rejeter le rapport</value>
+  </data>
+  <data name="DismissReportConfirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir rejeter (supprimer) ce rapport ? L'événement signalé ne sera pas supprimé du salon.</value>
+  </data>
+  <data name="DeleteRoomTitle" xml:space="preserve">
+    <value>Supprimer le salon</value>
+  </data>
+  <data name="DeleteRoomConfirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir supprimer ce salon ? Cela ne le bloquera PAS. Cette action est irréversible.</value>
+  </data>
+  <data name="DeleteAndBlockRoomTitle" xml:space="preserve">
+    <value>Supprimer et bloquer le salon</value>
+  </data>
+  <data name="DeleteAndBlockRoomConfirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir supprimer ET bloquer ce salon ? Cette action est irréversible.</value>
+  </data>
+  <data name="DeleteAndBlock" xml:space="preserve">
+    <value>Supprimer et bloquer</value>
+  </data>
+  <data name="QuarantineMediaTitle" xml:space="preserve">
+    <value>Mettre les médias en quarantaine</value>
+  </data>
+  <data name="QuarantineRoomMediaConfirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir mettre en quarantaine tous les médias de ce salon ?</value>
+  </data>
+  <data name="Quarantine" xml:space="preserve">
+    <value>Quarantaine</value>
+  </data>
+  <data name="DeactivateUserTitle" xml:space="preserve">
+    <value>Désactiver l'utilisateur</value>
+  </data>
+  <data name="DeactivateUserConfirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir désactiver cet utilisateur ?</value>
+  </data>
+  <data name="Deactivate" xml:space="preserve">
+    <value>Désactiver</value>
+  </data>
+  <data name="QuarantineUserMediaConfirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir mettre en quarantaine tous les médias téléchargés par cet utilisateur ?</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -604,4 +604,55 @@
   <data name="ErrorDeletingEventReport" xml:space="preserve">
     <value>Error deleting event report {0}: {1}</value>
   </data>
+  <data name="ResetConnectionTitle" xml:space="preserve">
+    <value>Reset Connection</value>
+  </data>
+  <data name="ResetConnectionConfirmation" xml:space="preserve">
+    <value>Are you sure you want to reset the federation connection backoff for {0}?</value>
+  </data>
+  <data name="Reset" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="DismissReportTitle" xml:space="preserve">
+    <value>Dismiss Report</value>
+  </data>
+  <data name="DismissReportConfirmation" xml:space="preserve">
+    <value>Are you sure you want to dismiss (delete) this report? The reported event will not be deleted from the room.</value>
+  </data>
+  <data name="DeleteRoomTitle" xml:space="preserve">
+    <value>Delete Room</value>
+  </data>
+  <data name="DeleteRoomConfirmation" xml:space="preserve">
+    <value>Are you sure you want to delete this room? This will NOT block it. This action cannot be undone.</value>
+  </data>
+  <data name="DeleteAndBlockRoomTitle" xml:space="preserve">
+    <value>Delete &amp; Block Room</value>
+  </data>
+  <data name="DeleteAndBlockRoomConfirmation" xml:space="preserve">
+    <value>Are you sure you want to delete AND block this room? This action cannot be undone.</value>
+  </data>
+  <data name="DeleteAndBlock" xml:space="preserve">
+    <value>Delete &amp; Block</value>
+  </data>
+  <data name="QuarantineMediaTitle" xml:space="preserve">
+    <value>Quarantine Media</value>
+  </data>
+  <data name="QuarantineRoomMediaConfirmation" xml:space="preserve">
+    <value>Are you sure you want to quarantine all media in this room?</value>
+  </data>
+  <data name="Quarantine" xml:space="preserve">
+    <value>Quarantine</value>
+  </data>
+  <data name="DeactivateUserTitle" xml:space="preserve">
+    <value>Deactivate User</value>
+  </data>
+  <data name="DeactivateUserConfirmation" xml:space="preserve">
+    <value>Are you sure you want to deactivate this user?</value>
+  </data>
+  <data name="Deactivate" xml:space="preserve">
+    <value>Deactivate</value>
+  </data>
+  <data name="QuarantineUserMediaConfirmation" xml:space="preserve">
+    <value>Are you sure you want to quarantine all media uploaded by this user?</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR fixes issue #60 by localizing all hardcoded strings in confirmation dialogs across the UI. \n\nIt also updates  with a refined localization rule that permits  files to use  specifically for Interaction Logic (like dialogs), while maintaining the requirement that services handle business-logic translations. Closes #60.