### PR TITLE
refactor: support reverse proxies and SSL termination

### DIFF
--- a/src/SynapseAdmin/Program.cs
+++ b/src/SynapseAdmin/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using MudBlazor.Translations;
 using Serilog;
+using Microsoft.AspNetCore.HttpOverrides;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -22,6 +23,14 @@ builder.Host.UseSerilog();
 builder.Services.AddControllers();
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    // Clear known networks and proxies so it works in Docker/Container environments
+    options.KnownIPNetworks.Clear();
+    options.KnownProxies.Clear();
+});
 
 builder.Services.AddRoryLibMatrixServices(new RoryLibMatrixConfiguration {
     AppName = "SynapseAdmin.NET"
@@ -50,12 +59,15 @@ builder.Services.AddMudServices();
 
 var app = builder.Build();
 
+app.UseForwardedHeaders();
+
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error", createScopeForErrors: true);
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
+    app.UseHttpsRedirection();
 }
 
 var supportedCultures = new[] { "en-US", "de-DE", "fr-FR" };
@@ -67,7 +79,6 @@ var localizationOptions = new RequestLocalizationOptions()
 app.UseRequestLocalization(localizationOptions);
 
 app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);
-app.UseHttpsRedirection();
 
 app.UseAntiforgery();
 


### PR DESCRIPTION
This PR adds support for forwarded headers (X-Forwarded-For and X-Forwarded-Proto) using the modern KnownIPNetworks configuration. This allows the app to correctly detect the client's protocol when running behind a reverse proxy (like Nginx, Traefik, or Cloudflare) with SSL termination. It also restricts HTTPS redirection to non-development environments.