### PR TITLE
feat: implement session caching in MatrixSessionService

### DIFF
--- a/src/SynapseAdmin/Interfaces/IMatrixSessionService.cs
+++ b/src/SynapseAdmin/Interfaces/IMatrixSessionService.cs
@@ -8,6 +8,6 @@ public interface IMatrixSessionService
     AuthenticatedHomeserverGeneric? AuthenticatedHomeserver { get; }
     bool IsLoggedIn { get; }
     Task<OperationResult> LoginAsync(string homeserver, string username, string password);
-    Task<OperationResult> RestoreSessionAsync(string homeserver, string accessToken);
+    Task<OperationResult> RestoreSessionAsync(string homeserver, string accessToken, bool force = false);
     void Logout();
 }

--- a/src/SynapseAdmin/Services/MatrixSessionService.cs
+++ b/src/SynapseAdmin/Services/MatrixSessionService.cs
@@ -29,8 +29,15 @@ public class MatrixSessionService(HomeserverProviderService hsProvider, ILogger<
         }
     }
 
-    public async Task<OperationResult> RestoreSessionAsync(string homeserver, string accessToken)
+    public async Task<OperationResult> RestoreSessionAsync(string homeserver, string accessToken, bool force = false)
     {
+        if (!force && AuthenticatedHomeserver != null && 
+            AuthenticatedHomeserver.BaseUrl == homeserver && 
+            AuthenticatedHomeserver.AccessToken == accessToken)
+        {
+            return OperationResult.Ok();
+        }
+
         try
         {
             AuthenticatedHomeserver = await hsProvider.GetAuthenticatedWithToken(homeserver, accessToken);


### PR DESCRIPTION
Reduces redundant homeserver calls by skipping token validation if the session is already active in memory.