### PR TITLE
refactor: make GHCR the default in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,26 +68,36 @@ dotnet run --project src/SynapseAdmin/SynapseAdmin.csproj
 
 ### Running with Docker
 
-You can use the official pre-built images from the [GitHub Container Registry](https://github.com/benjamin-aicheler/SynapseAdmin.NET/pkgs/container/synapseadmin.net):
+You can run the application using our pre-built images from the [GitHub Container Registry](https://github.com/benjamin-aicheler/SynapseAdmin.NET/pkgs/container/synapseadmin.net).
+
+#### Using Docker Compose (Recommended)
+The easiest way to get started is by using the default `docker-compose.yml` file:
 
 ```bash
-docker pull ghcr.io/benjamin-aicheler/synapseadmin.net:latest
+docker compose up -d
 ```
 
-Alternatively, to run the application using Docker Compose with the provided `docker-compose.yml`:
+This will:
+- Pull the latest image from GHCR.
+- Map port `8080` for the web interface.
+- Persist application logs to a `./logs` directory on your host.
+
+#### Using Docker CLI
+Alternatively, you can run the container directly:
 
 ```bash
-docker compose up --build
+docker run -d \
+  -p 8080:8080 \
+  -v ./logs:/app/logs \
+  --name synapseadmin \
+  ghcr.io/benjamin-aicheler/synapseadmin.net:latest
 ```
 
-The application logs are stored in the `/app/logs` directory within the container. You can mount a volume to this directory to persist logs on the host:
+#### Building from Source
+If you prefer to build the image yourself, use the provided build-specific compose file:
 
-```yaml
-services:
-  synapseadmin:
-    image: ghcr.io/benjamin-aicheler/synapseadmin.net:latest
-    volumes:
-      - ./logs:/app/logs
+```bash
+docker compose -f docker-compose.build.yml up --build
 ```
 
 ### Reverse Proxy Configuration

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,10 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: src/SynapseAdmin/Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - ASPNETCORE_HTTP_PORTS=8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
 services:
-  web:
-    build:
-      context: .
-      dockerfile: src/SynapseAdmin/Dockerfile
+  synapseadmin:
+    image: ghcr.io/benjamin-aicheler/synapseadmin.net:latest
+    container_name: synapseadmin
     ports:
       - "8080:8080"
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - ASPNETCORE_HTTP_PORTS=8080
+    volumes:
+      - ./logs:/app/logs
+    restart: unless-stopped


### PR DESCRIPTION
Swaps the Docker Compose files to make the GHCR image the default deployment method. The build-from-source configuration is now in docker-compose.build.yml.