### PR TITLE
fix: persist ASP.NET DataProtection keys via volume

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -8,3 +8,6 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - ASPNETCORE_HTTP_PORTS=8080
+    volumes:
+      - ./logs:/app/logs
+      - ./keys:/root/.aspnet/DataProtection-Keys

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,5 @@ services:
       - ASPNETCORE_HTTP_PORTS=8080
     volumes:
       - ./logs:/app/logs
+      - ./keys:/root/.aspnet/DataProtection-Keys
     restart: unless-stopped


### PR DESCRIPTION
Adds volume mapping for /root/.aspnet/DataProtection-Keys to ensure that the encryption keys are persisted on the host, preventing users from being logged out when the container is recreated.