### PR TITLE
feat: encrypt DataProtection keys with passphrase (Issue #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ dotnet run --project src/SynapseAdmin/SynapseAdmin.csproj
 You can run the application using our pre-built images from the [GitHub Container Registry](https://github.com/benjamin-aicheler/SynapseAdmin.NET/pkgs/container/synapseadmin.net).
 
 #### Using Docker Compose (Recommended)
-The easiest way to get started is by using the default `docker-compose.yml` file:
+The easiest way to get started is by using the default `docker-compose.yml` file. **Important:** Change the `DP_PASSPHRASE` value in the file to a secure, random string to encrypt your session keys on disk.
 
 ```bash
 docker compose up -d
@@ -82,13 +82,15 @@ This will:
 - Map port `8080` for the web interface.
 - Persist application logs to a `./logs` directory on your host.
 - Persist encryption keys to a `./keys` directory on your host (keeps you logged in across restarts).
+- **Encrypt** the persisted keys using the `DP_PASSPHRASE`.
 
 #### Using Docker CLI
-Alternatively, you can run the container directly:
+Alternatively, you can run the container directly. Make sure to provide a secure passphrase:
 
 ```bash
 docker run -d \
   -p 8080:8080 \
+  -e DP_PASSPHRASE="your-secure-passphrase-here" \
   -v ./logs:/app/logs \
   -v ./keys:/root/.aspnet/DataProtection-Keys \
   --name synapseadmin \

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -8,6 +8,7 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - ASPNETCORE_HTTP_PORTS=8080
+      - DP_PASSPHRASE=your-secure-passphrase-here
     volumes:
       - ./logs:/app/logs
       - ./keys:/root/.aspnet/DataProtection-Keys

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - ASPNETCORE_HTTP_PORTS=8080
+      - DP_PASSPHRASE=your-secure-passphrase-here
     volumes:
       - ./logs:/app/logs
       - ./keys:/root/.aspnet/DataProtection-Keys

--- a/src/SynapseAdmin/Infrastructure/DataProtection/AesXmlDecryptor.cs
+++ b/src/SynapseAdmin/Infrastructure/DataProtection/AesXmlDecryptor.cs
@@ -1,0 +1,35 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.AspNetCore.DataProtection.XmlEncryption;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SynapseAdmin.Infrastructure.DataProtection;
+
+public class AesXmlDecryptor(IServiceProvider services) : IXmlDecryptor
+{
+    private const int KeySize = 32; // 256 bits
+    private const int Iterations = 100_000;
+
+    public XElement Decrypt(XElement encryptedElement)
+    {
+        var passphrase = services.GetRequiredService<IConfiguration>()["DP_PASSPHRASE"];
+        if (string.IsNullOrEmpty(passphrase))
+        {
+            throw new InvalidOperationException("DP_PASSPHRASE environment variable is missing for decryption.");
+        }
+
+        var salt = Convert.FromBase64String(encryptedElement.Element("salt")!.Value);
+        var nonce = Convert.FromBase64String(encryptedElement.Element("nonce")!.Value);
+        var tag = Convert.FromBase64String(encryptedElement.Element("tag")!.Value);
+        var ciphertext = Convert.FromBase64String(encryptedElement.Element("ciphertext")!.Value);
+
+        var plaintext = new byte[ciphertext.Length];
+
+        var key = Rfc2898DeriveBytes.Pbkdf2(passphrase, salt, Iterations, HashAlgorithmName.SHA256, KeySize);
+        using var aesGcm = new AesGcm(key, tag.Length);
+        aesGcm.Decrypt(nonce, ciphertext, tag, plaintext);
+
+        return XElement.Parse(Encoding.UTF8.GetString(plaintext));
+    }
+}

--- a/src/SynapseAdmin/Infrastructure/DataProtection/AesXmlEncryptor.cs
+++ b/src/SynapseAdmin/Infrastructure/DataProtection/AesXmlEncryptor.cs
@@ -1,0 +1,37 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.AspNetCore.DataProtection.XmlEncryption;
+
+namespace SynapseAdmin.Infrastructure.DataProtection;
+
+public class AesXmlEncryptor(string passphrase) : IXmlEncryptor
+{
+    private const int KeySize = 32; // 256 bits
+    private const int NonceSize = 12; // Standard for AES-GCM
+    private const int TagSize = 16; // Standard for AES-GCM
+    private const int Iterations = 100_000;
+
+    public EncryptedXmlInfo Encrypt(XElement plaintextElement)
+    {
+        var plaintext = Encoding.UTF8.GetBytes(plaintextElement.ToString(SaveOptions.DisableFormatting));
+        var salt = RandomNumberGenerator.GetBytes(16);
+        var nonce = RandomNumberGenerator.GetBytes(NonceSize);
+        var tag = new byte[TagSize];
+        var ciphertext = new byte[plaintext.Length];
+
+        var key = Rfc2898DeriveBytes.Pbkdf2(passphrase, salt, Iterations, HashAlgorithmName.SHA256, KeySize);
+        using var aesGcm = new AesGcm(key, TagSize);
+        aesGcm.Encrypt(nonce, plaintext, ciphertext, tag);
+
+        var element = new XElement("encryptedKey",
+            new XAttribute("v", "1"),
+            new XElement("salt", Convert.ToBase64String(salt)),
+            new XElement("nonce", Convert.ToBase64String(nonce)),
+            new XElement("tag", Convert.ToBase64String(tag)),
+            new XElement("ciphertext", Convert.ToBase64String(ciphertext))
+        );
+
+        return new EncryptedXmlInfo(element, typeof(AesXmlDecryptor));
+    }
+}

--- a/src/SynapseAdmin/Program.cs
+++ b/src/SynapseAdmin/Program.cs
@@ -9,6 +9,8 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using MudBlazor.Translations;
 using Serilog;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.DataProtection;
+using SynapseAdmin.Infrastructure.DataProtection;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -23,6 +25,15 @@ builder.Host.UseSerilog();
 builder.Services.AddControllers();
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+
+var dpBuilder = builder.Services.AddDataProtection()
+    .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(builder.Environment.ContentRootPath, "keys")));
+
+var passphrase = builder.Configuration["DP_PASSPHRASE"];
+if (!string.IsNullOrEmpty(passphrase))
+{
+    dpBuilder.AddKeyManagementOptions(options => options.XmlEncryptor = new AesXmlEncryptor(passphrase));
+}
 
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {

--- a/src/SynapseAdmin/appsettings.json
+++ b/src/SynapseAdmin/appsettings.json
@@ -28,5 +28,6 @@
     ],
     "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "DP_PASSPHRASE": ""
 }


### PR DESCRIPTION
Implements Issue #74 by providing a custom AES-GCM XML encryptor for ASP.NET DataProtection.

- **Security:** Keys are AES-256-GCM encrypted on disk.
- **Portability:** Works across Docker, Linux, macOS, and Windows.
- **Configuration:** Users provide a `DP_PASSPHRASE` environment variable or appsetting.

Closes #74