### PR TITLE
fix: align Data Protection persistence paths and update documentation

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -41,9 +41,9 @@ The project uses the standard .NET 10 CLI and Docker:
 
 ## Security
 - **Data Protection:** The application uses ASP.NET Core Data Protection to encrypt sensitive session data (Matrix access tokens). 
-    - **Docker:** Keys are persisted to the host via a volume mount to `./keys` (\`/root/.aspnet/DataProtection-Keys\` in the container).
-    - **Host:** Keys are stored in the user's home directory (\`~/.aspnet/DataProtection-Keys\`).
-- **Encryption at Rest:** (Planned - Issue #74) Implement a universal passphrase-based encryption for DataProtection keys to ensure they are encrypted on disk even if the storage directory is compromised.
+    - **Docker:** Keys are persisted to the host via a volume mount to `./keys` (\`/app/keys\` in the container).
+    - **Host:** Keys are stored in the application's root directory (\`./keys\`).
+- **Encryption at Rest:** Implemented a universal passphrase-based encryption (AES-256-GCM) for DataProtection keys to ensure they are encrypted on disk.
 
 ## Git & GitHub Workflow
 We strictly follow the **GitHub Flow**. Direct commits to the `main` branch are prohibited.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ docker run -d \
   -p 8080:8080 \
   -e DP_PASSPHRASE="your-secure-passphrase-here" \
   -v ./logs:/app/logs \
-  -v ./keys:/root/.aspnet/DataProtection-Keys \
+  -v ./keys:/app/keys \
   --name synapseadmin \
   ghcr.io/benjamin-aicheler/synapseadmin.net:latest
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,5 @@ services:
       - DP_PASSPHRASE=your-secure-passphrase-here
     volumes:
       - ./logs:/app/logs
-      - ./keys:/root/.aspnet/DataProtection-Keys
+      - ./keys:/app/keys
     restart: unless-stopped


### PR DESCRIPTION
This PR fixes a discrepancy where the application was configured to look for Data Protection keys at `/app/keys`, but Docker was mounting them at `/root/.aspnet/DataProtection-Keys`.

Changes:
- Updated `docker-compose.yml` and `README.md` to mount to `/app/keys`.
- Updated `GEMINI.md` to reflect the correct persistence path and confirm that **Encryption at Rest** (Issue #74) is implemented.

This resolves the warning about non-persistent keys and ensures session persistence across container restarts.