### PR TITLE
refactor: remove redundant Task.WhenAll and double-await in RoomService

### DIFF
--- a/src/SynapseAdmin/Services/RoomService.cs
+++ b/src/SynapseAdmin/Services/RoomService.cs
@@ -68,12 +68,8 @@ public class RoomService(IMatrixSessionService sessionService, ILogger<RoomServi
             
             if (r == null) return OperationResult<RoomDetailViewModel>.Failure(L["RoomNotFound"]);
 
-            var membersTask = SynapseAdmin.Admin.GetRoomMembersAsync(roomId);
-            var stateTask = SynapseAdmin.Admin.GetRoomStateAsync(roomId);
-            await Task.WhenAll(membersTask, stateTask);
-
-            var members = await membersTask;
-            var stateEvents = await stateTask;
+            var members = await SynapseAdmin.Admin.GetRoomMembersAsync(roomId);
+            var stateEvents = await SynapseAdmin.Admin.GetRoomStateAsync(roomId);
             var tombstone = stateEvents?.Events
                 .FirstOrDefault(x => x.Type == RoomTombstoneEventContent.EventId)?
                 .ContentAs<RoomTombstoneEventContent>();


### PR DESCRIPTION
Resolves #85. Simplified await logic in GetRoomDetailsAsync for improved clarity.