### PR TITLE
fix: map room_id to alphabetical for room list sorting (#84)

### DIFF
--- a/src/SynapseAdmin/Services/RoomService.cs
+++ b/src/SynapseAdmin/Services/RoomService.cs
@@ -21,6 +21,7 @@ public class RoomService(IMatrixSessionService sessionService, ILogger<RoomServi
 
         try
         {
+            if (orderBy == "room_id") orderBy = "alphabetical";
             var dir = direction == SortDirection.Descending ? "b" : "f";
             var url = $"/_synapse/admin/v1/rooms?from={offset}&limit={limit}&dir={dir}&order_by={Uri.EscapeDataString(orderBy)}";
             if (!string.IsNullOrEmpty(searchTerm))


### PR DESCRIPTION
Resolves #84. Maps 'room_id' sorting to 'alphabetical' as Synapse Admin API doesn't support 'room_id' directly for sorting.