### PR TITLE
Correct event reports link on dashboard

### DIFF
--- a/src/SynapseAdmin/Components/Pages/Home.razor
+++ b/src/SynapseAdmin/Components/Pages/Home.razor
@@ -76,7 +76,7 @@ else if (isSynapse)
                 <ToolBarContent>
                     <MudText Typo="Typo.h6">@L["LatestEventReports"]</MudText>
                     <MudSpacer />
-                    <MudButton Variant="Variant.Text" Color="Color.Primary" Href="/event-reports">@L["Details"]</MudButton>
+                    <MudButton Variant="Variant.Text" Color="Color.Primary" Href="/reports">@L["Details"]</MudButton>
                 </ToolBarContent>
                 <HeaderContent>
                     <MudTh>@L["Reporter"]</MudTh>


### PR DESCRIPTION
Fixes a broken link on the dashboard where event reports pointed to /event-reports instead of /reports.