### PR TITLE
perf: optimize RoomDetails and Home async handling

### DIFF
--- a/src/SynapseAdmin/Components/Pages/Home.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/Home.razor.cs
@@ -54,21 +54,25 @@ namespace SynapseAdmin.Components.Pages
 
                 await Task.WhenAll(userTask, roomTask, reportTask);
 
-                if (userTask.Result.Success)
+                var userResult = await userTask;
+                var roomResult = await roomTask;
+                var reportResult = await reportTask;
+
+                if (userResult.Success)
                 {
-                    totalUsers = userTask.Result.Data.Total;
-                    latestUsers = userTask.Result.Data.Users;
+                    totalUsers = userResult.Data.Total;
+                    latestUsers = userResult.Data.Users;
                 }
 
-                if (roomTask.Result.Success)
+                if (roomResult.Success)
                 {
-                    totalRooms = roomTask.Result.Data.Total;
+                    totalRooms = roomResult.Data.Total;
                 }
 
-                if (reportTask.Result.Success)
+                if (reportResult.Success)
                 {
-                    totalReports = reportTask.Result.Data.Total;
-                    latestReports = reportTask.Result.Data.Reports;
+                    totalReports = reportResult.Data.Total;
+                    latestReports = reportResult.Data.Reports;
                 }
             }
             finally

--- a/src/SynapseAdmin/Services/RoomService.cs
+++ b/src/SynapseAdmin/Services/RoomService.cs
@@ -69,8 +69,14 @@ public class RoomService(IMatrixSessionService sessionService, ILogger<RoomServi
             
             if (r == null) return OperationResult<RoomDetailViewModel>.Failure(L["RoomNotFound"]);
 
-            var members = await SynapseAdmin.Admin.GetRoomMembersAsync(roomId);
-            var stateEvents = await SynapseAdmin.Admin.GetRoomStateAsync(roomId);
+            var membersTask = SynapseAdmin.Admin.GetRoomMembersAsync(roomId);
+            var stateTask = SynapseAdmin.Admin.GetRoomStateAsync(roomId);
+
+            await Task.WhenAll(membersTask, stateTask);
+
+            var members = await membersTask;
+            var stateEvents = await stateTask;
+            
             var tombstone = stateEvents?.Events
                 .FirstOrDefault(x => x.Type == RoomTombstoneEventContent.EventId)?
                 .ContentAs<RoomTombstoneEventContent>();


### PR DESCRIPTION
This PR parallelizes API calls in RoomService.GetRoomDetailsAsync and refactors Home.razor.cs to use await instead of .Result, improving performance and idiomatic async usage.