### PR TITLE
Potential fix for code scanning alert no. 30: Log entries created from user input

### DIFF
--- a/src/SynapseAdmin/Extensions/LoggingExtensions.cs
+++ b/src/SynapseAdmin/Extensions/LoggingExtensions.cs
@@ -3,17 +3,23 @@ namespace SynapseAdmin.Extensions;
 public static class LoggingExtensions
 {
     /// <summary>
-    /// Sanitizes a string for safe logging by removing line breaks and trimming.
+    /// Sanitizes a string for safe logging by removing line breaks, control characters and trimming.
     /// This prevents Log Injection/Forging vulnerabilities (CodeQL cs/log-forging).
     /// </summary>
     public static string? SanitizeForLogging(this string? input)
     {
         if (string.IsNullOrEmpty(input)) return input;
 
-        return input
-            .Replace(Environment.NewLine, string.Empty)
+        // Work on a copy and remove all newline variants and control characters.
+        var sanitized = input
+            .Replace("\r\n", string.Empty)
+            .Replace("\n\r", string.Empty)
             .Replace("\n", string.Empty)
-            .Replace("\r", string.Empty)
-            .Trim();
+            .Replace("\r", string.Empty);
+
+        // Strip remaining control characters (except tab) to avoid hidden log manipulation.
+        sanitized = new string(sanitized.Where(c => !char.IsControl(c) || c == '\t').ToArray());
+
+        return sanitized.Trim();
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/benjamin-aicheler/SynapseAdmin.NET/security/code-scanning/30](https://github.com/benjamin-aicheler/SynapseAdmin.NET/security/code-scanning/30)

General approach: Ensure that any user-provided data passed into logging APIs is normalized to remove log-forging vectors (line breaks and other control characters) in a way that CodeQL recognizes as a proper sanitization step. Centralize this in `SanitizeForLogging`, so call sites stay the same and functionality is unchanged except for safer logging representation.

Best concrete fix: Update `SanitizeForLogging` in `src/SynapseAdmin/Extensions/LoggingExtensions.cs` to (1) always return a new, cleaned string instance, (2) handle all standard newline representations using their explicit escape forms, and (3) optionally strip a broader set of control characters in the ASCII control range. This strengthens the sanitization without changing how the application behaves from a user’s perspective, and does not require any changes in `UserService.cs` or `UserDetails.razor.cs`, which already call `SanitizeForLogging()` in the relevant log statements.

Specific changes:

- In `LoggingExtensions.cs`, adjust the implementation of `SanitizeForLogging`:
  - Avoid returning `input` directly; instead, work on a local `sanitized` variable, and always return that (or `string.Empty` if you prefer, but we can keep null/empty behavior consistent).
  - Explicitly remove `"\r\n"`, `"\n\r"`, `"\n"`, and `"\r"` to cover all newline combinations, instead of relying only on `Environment.NewLine`.
  - Remove other non-printable control characters via `Where(c => !char.IsControl(c) || c == '\t')` or similar, if you want broader protection, while preserving normal printable characters.

No new methods or imports are needed beyond what is already in `LoggingExtensions.cs`; we only modify the body of `SanitizeForLogging`. All existing call sites (in `UserService`) remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
