### PR TITLE
Potential fix for code scanning alert no. 31: Cookie 'Secure' attribute is not set to true

### DIFF
--- a/src/SynapseAdmin/Controllers/CultureController.cs
+++ b/src/SynapseAdmin/Controllers/CultureController.cs
@@ -15,7 +15,8 @@ public class CultureController : Controller
                 CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture, culture)),
                 new CookieOptions
                 {
-                    Expires = DateTimeOffset.UtcNow.AddYears(1)
+                    Expires = DateTimeOffset.UtcNow.AddYears(1),
+                    Secure = true
                 });
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/benjamin-aicheler/SynapseAdmin.NET/security/code-scanning/31](https://github.com/benjamin-aicheler/SynapseAdmin.NET/security/code-scanning/31)

In general, to fix this type of issue in ASP.NET Core, ensure that any `CookieOptions` used with `Response.Cookies.Append` has `Secure = true` (or rely on a global `CookiePolicyOptions` with `Secure = CookieSecurePolicy.Always`). This ensures the cookie is only sent over HTTPS connections.

For this specific controller, the best fix without changing existing functionality is to update the `CookieOptions` object created on line 16 in `CultureController.Set` to include `Secure = true` while preserving the existing `Expires` setting. This keeps the cookie’s expiry behavior and name/value as-is but marks it as a secure cookie.

Concretely, in `src/SynapseAdmin/Controllers/CultureController.cs`, modify the object initializer for `new CookieOptions` so it sets both `Expires` and `Secure`. No new imports or helper methods are required because `CookieOptions.Secure` is already available in the current namespace and type.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
