### PR TITLE
Potential fix for code scanning alert no. 29: Log entries created from user input

### DIFF
--- a/src/SynapseAdmin/Extensions/LoggingExtensions.cs
+++ b/src/SynapseAdmin/Extensions/LoggingExtensions.cs
@@ -13,7 +13,8 @@ public static class LoggingExtensions
     /// <returns>A sanitized and truncated string safe for logging.</returns>
     public static string? SanitizeForLogging(this string? input, int maxLength = DefaultMaxLogLength)
     {
-        if (string.IsNullOrEmpty(input)) return input;
+        // Always return a sanitized value, never the original (tainted) reference.
+        if (string.IsNullOrEmpty(input)) return string.Empty;
 
         // Work on a local copy so we never return the original (tainted) reference.
         var sanitized = input;


### PR DESCRIPTION
Potential fix for [https://github.com/benjamin-aicheler/SynapseAdmin.NET/security/code-scanning/29](https://github.com/benjamin-aicheler/SynapseAdmin.NET/security/code-scanning/29)

Generally, to fix log-forging issues you must ensure that any user-provided value is sanitized before being logged and that the sanitizer is guaranteed not to return the original tainted reference and to remove/neutralize all characters that can break log structure (newlines, control chars, escape sequences). In this codebase, all the relevant logging calls already use `userId.SanitizeForLogging()`, so the primary improvement is to make `SanitizeForLogging` always return a sanitized copy, even for null/empty inputs, so static analysis tools treat it as a proper sanitizer and there is no propagation of tainted data.

Concretely, in `src/SynapseAdmin/Extensions/LoggingExtensions.cs`, adjust `SanitizeForLogging` so that:

- It never returns `input` directly; instead, it returns either a constant safe value or a new string instance.
- The null/empty case returns a safe constant like `string.Empty` (or a placeholder) instead of the original `input` reference.
- The rest of the method can remain as-is: truncation, newline replacement, and ASCII filtering already protect against log forging and control characters.

No changes are needed in `UserService.cs` or `UserDetails.razor.cs` because they are already calling `SanitizeForLogging` in all logging calls that use `userId`. We only touch the sanitizer implementation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
