### PR TITLE
feat: add copy-to-clipboard for registration tokens

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RegistrationTokens.razor
+++ b/src/SynapseAdmin/Components/Pages/RegistrationTokens.razor
@@ -35,7 +35,12 @@ else
             <MudTh>@L["Actions"]</MudTh>
         </HeaderContent>
         <RowTemplate>
-            <MudTd DataLabel="@L["Token"]"><MudText Typo="Typo.body2">@context.Token</MudText></MudTd>
+            <MudTd DataLabel="@L["Token"]">
+                <MudStack Row="true" AlignItems="AlignItems.Center">
+                    <MudText Typo="Typo.body2">@context.Token</MudText>
+                    <MudIconButton Icon="@Icons.Material.Filled.ContentCopy" Size="Size.Small" OnClick="@(() => CopyToClipboard(context.Token))" Title="@L["CopyToClipboard"]" />
+                </MudStack>
+            </MudTd>
             <MudTd DataLabel="@L["Uses"]">
                 @context.Completed / @(context.UsesAllowed.HasValue ? context.UsesAllowed.Value.ToString() : L["Unlimited"])
             </MudTd>

--- a/src/SynapseAdmin/Components/Pages/RegistrationTokens.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RegistrationTokens.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using MudBlazor;
 using SynapseAdmin.Models.ViewModels;
 using SynapseAdmin.Interfaces;
@@ -17,6 +18,8 @@ namespace SynapseAdmin.Components.Pages
         public ISnackbar Snackbar { get; set; } = null!;
         [Inject] 
         public IDialogService DialogService { get; set; } = null!;
+        [Inject]
+        public IJSRuntime JSRuntime { get; set; } = null!;
 
         private List<RegistrationTokenViewModel> tokens = new();
         private bool isLoading = true;
@@ -98,6 +101,19 @@ namespace SynapseAdmin.Components.Pages
                 {
                     await LoadTokens();
                 }
+            }
+        }
+
+        private async Task CopyToClipboard(string text)
+        {
+            try
+            {
+                await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text);
+                Snackbar.Add(L["TokenCopiedToClipboard"], Severity.Success);
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add(L["ErrorCopyingToClipboard"], Severity.Error);
             }
         }
     }

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -685,4 +685,13 @@
   <data name="ErrorFetchingTopMediaUsers" xml:space="preserve">
     <value>Fehler beim Abrufen der Benutzer mit den meisten Medien.</value>
   </data>
+  <data name="TokenCopiedToClipboard" xml:space="preserve">
+    <value>Token in Zwischenablage kopiert!</value>
+  </data>
+  <data name="ErrorCopyingToClipboard" xml:space="preserve">
+    <value>Fehler beim Kopieren in die Zwischenablage.</value>
+  </data>
+  <data name="CopyToClipboard" xml:space="preserve">
+    <value>In Zwischenablage kopieren</value>
+  </data>
   </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -685,4 +685,13 @@
   <data name="ErrorFetchingTopMediaUsers" xml:space="preserve">
     <value>Erreur lors de la récupération des utilisateurs avec le plus de médias.</value>
   </data>
+  <data name="TokenCopiedToClipboard" xml:space="preserve">
+    <value>Token copié dans le presse-papiers !</value>
+  </data>
+  <data name="ErrorCopyingToClipboard" xml:space="preserve">
+    <value>Erreur lors de la copie dans le presse-papiers.</value>
+  </data>
+  <data name="CopyToClipboard" xml:space="preserve">
+    <value>Copier dans le presse-papiers</value>
+  </data>
   </root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -685,4 +685,13 @@
   <data name="ErrorFetchingTopMediaUsers" xml:space="preserve">
     <value>Error fetching top media users.</value>
   </data>
+  <data name="TokenCopiedToClipboard" xml:space="preserve">
+    <value>Token copied to clipboard!</value>
+  </data>
+  <data name="ErrorCopyingToClipboard" xml:space="preserve">
+    <value>Error copying to clipboard.</value>
+  </data>
+  <data name="CopyToClipboard" xml:space="preserve">
+    <value>Copy to clipboard</value>
+  </data>
   </root>


### PR DESCRIPTION
This PR adds a 'Copy' button to the Registration Tokens table to improve the user experience when managing server registration.

### Changes:
- **RegistrationTokens**: Added icon button to copy token strings directly to the clipboard.
- **Localization**: Added success/error strings in EN, DE, and FR.

Closes #108