### PR TITLE
feat: add user registration functionality (#131)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@ SynapseAdmin.NET is a .NET 10 Blazor Server Web App for administering Synapse (M
 - **Logging:** Serilog (Console and rolling File logging to `logs/` directory)
 - **Deployment:** Docker & Docker Compose
 - **License:** GNU Affero General Public License v3.0 (AGPL-3.0)
-- **Status:** Active Development; basic auth, dashboard, room/user management, event reports, registration tokens, federation destinations, server notices, multi-language support (EN, DE, FR), and MudBlazor UI are implemented.
+- **Status:** Active Development; basic auth, dashboard, room/user management (including creation), event reports, registration tokens, federation destinations, server notices, multi-language support (EN, DE, FR), and MudBlazor UI are implemented.
 
 ## Building and Running
 The project uses the standard .NET 10 CLI and Docker:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A modern .NET 10 Blazor Server web application for administering Synapse (Matrix
 SynapseAdmin.NET provides a comprehensive suite of tools to manage your Matrix homeserver right from your browser. Current capabilities include:
 
 - **Dashboard:** At-a-glance overview of your server's status and metrics, including Synapse version, room storage usage, and user media consumption.
-- **User Management:** Search, view, deactivate, and manage properties of server users.
+- **User Management:** Search, view, create, deactivate, and manage properties of server users.
 - **Room Management:** Search and inspect server rooms and their details.
 - **Event Reports:** Review and manage reported events/messages from users.
 - **Registration Tokens:** Generate and manage tokens to restrict server registration.

--- a/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor
+++ b/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor
@@ -1,0 +1,41 @@
+@using SynapseAdmin.Models.ViewModels
+@using SynapseAdmin.Interfaces
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.PersonAdd" Class="mr-3 mb-n1" />
+            @L["CreateUser"]
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudForm @ref="form" @bind-IsValid="@success">
+            <MudTextField T="string" Label="@L["UserId"]" @bind-Value="model.UserId" Required="true" 
+                          RequiredError="@L["UserIdRequired"]" HelperText="@L["UserIdFormatHelper"]" 
+                          Validation="@(new Func<string, string?>(v => !string.IsNullOrEmpty(v) && !v.StartsWith("@") ? "Must start with @" : null))" />
+            
+            <MudTextField T="string" Label="@L["Password"]" @bind-Value="model.Password" Required="true" 
+                          InputType="InputType.Password" RequiredError="@L["PasswordRequired"]" />
+            
+            <MudTextField T="string" Label="@L["DisplayName"]" @bind-Value="model.DisplayName" />
+            
+            <MudSwitch T="bool" Label="@L["Admin"]" @bind-Value="model.Admin" Color="Color.Primary" />
+            
+            <MudSwitch T="bool" Label="@L["Deactivated"]" @bind-Value="model.Deactivated" Color="Color.Error" />
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">@L["Cancel"]</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit" Disabled="@(!success || loading)">
+            @if (loading)
+            {
+                <MudProgressCircular Class="ms-n1" Size="Size.Small" Indeterminate="true" />
+                <MudText Class="ms-2">@L["Loading"]</MudText>
+            }
+            else
+            {
+                @L["Create"]
+            }
+        </MudButton>
+    </DialogActions>
+</MudDialog>

--- a/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using SynapseAdmin.Interfaces;
+using SynapseAdmin.Models.ViewModels;
+using SynapseAdmin.Resources;
+using Microsoft.Extensions.Localization;
+
+namespace SynapseAdmin.Components.Pages;
+
+public partial class UserCreateDialog
+{
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [Inject] private IUserService UserService { get; set; } = default!;
+    [Inject] private ISnackbar Snackbar { get; set; } = default!;
+
+    private UserCreateViewModel model = new();
+    private MudForm form = default!;
+    private bool success;
+    private bool loading;
+
+    private async Task Submit()
+    {
+        await form.ValidateAsync();
+
+        if (form.IsValid)
+        {
+            loading = true;
+            var result = await UserService.CreateUserAsync(model);
+            loading = false;
+
+            if (result.Success)
+            {
+                Snackbar.Add(result.Message, result.Severity);
+                MudDialog.Close(DialogResult.Ok(true));
+            }
+            else
+            {
+                Snackbar.Add(result.Message, result.Severity);
+            }
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/src/SynapseAdmin/Components/Pages/Users.razor
+++ b/src/SynapseAdmin/Components/Pages/Users.razor
@@ -18,8 +18,11 @@
 else
 {
     <MudToolBar Class="mb-4">
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ReloadTable" StartIcon="@Icons.Material.Filled.Refresh">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ReloadTable" StartIcon="@Icons.Material.Filled.Refresh" Class="mr-2">
             @L["Refresh"]
+        </MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="OpenCreateUserDialog" StartIcon="@Icons.Material.Filled.PersonAdd">
+            @L["CreateUser"]
         </MudButton>
         <MudSpacer />
         @if (totalUsers.HasValue)

--- a/src/SynapseAdmin/Components/Pages/Users.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/Users.razor.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 using MudBlazor;
 using SynapseAdmin.Models.ViewModels;
 using SynapseAdmin.Interfaces;
+using SynapseAdmin.Resources;
 
 namespace SynapseAdmin.Components.Pages
 {
@@ -15,6 +17,8 @@ namespace SynapseAdmin.Components.Pages
         public NavigationManager Navigation { get; set; } = null!;
         [Inject]
         public ISnackbar Snackbar { get; set; } = null!;
+        [Inject]
+        public IDialogService DialogService { get; set; } = null!;
 
         private MudTable<UserListViewModel>? table;
         private int? totalUsers;
@@ -24,6 +28,18 @@ namespace SynapseAdmin.Components.Pages
             if (table != null)
             {
                 await table.ReloadServerData();
+            }
+        }
+
+        private async Task OpenCreateUserDialog()
+        {
+            var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+            var dialog = await DialogService.ShowAsync<UserCreateDialog>(L["CreateUser"], options);
+            var result = await dialog.Result;
+
+            if (result != null && !result.Canceled)
+            {
+                await ReloadTable();
             }
         }
 

--- a/src/SynapseAdmin/Interfaces/IUserService.cs
+++ b/src/SynapseAdmin/Interfaces/IUserService.cs
@@ -13,4 +13,5 @@ public interface IUserService
     Task<OperationResult<string>> LoginAsUserAsync(string userId, TimeSpan expireIn);
     Task<OperationResult> SendServerNoticeAsync(string userId, string message);
     Task<OperationResult<List<UserMediaStatisticsViewModel>>> GetTopMediaUsersAsync(int count = 10);
+    Task<OperationResult> CreateUserAsync(UserCreateViewModel model);
 }

--- a/src/SynapseAdmin/Models/Requests/SynapseAdminUserUpsertRequest.cs
+++ b/src/SynapseAdmin/Models/Requests/SynapseAdminUserUpsertRequest.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace SynapseAdmin.Models.Requests;
+
+public class SynapseAdminUserUpsertRequest
+{
+    [JsonPropertyName("password")]
+    public string? Password { get; set; }
+
+    [JsonPropertyName("displayname")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("admin")]
+    public bool? Admin { get; set; }
+
+    [JsonPropertyName("deactivated")]
+    public bool? Deactivated { get; set; }
+
+    [JsonPropertyName("avatar_url")]
+    public string? AvatarUrl { get; set; }
+
+    [JsonPropertyName("user_type")]
+    public string? UserType { get; set; }
+
+    [JsonPropertyName("locked")]
+    public bool? Locked { get; set; }
+
+    [JsonPropertyName("shadow_banned")]
+    public bool? ShadowBanned { get; set; }
+}

--- a/src/SynapseAdmin/Models/ViewModels/UserCreateViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/UserCreateViewModel.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SynapseAdmin.Models.ViewModels;
+
+public class UserCreateViewModel
+{
+    [Required]
+    [RegularExpression(@"^@[a-z0-9._=\-/]+:[a-z0-9.-]+\.[a-z]{2,}$", ErrorMessage = "Invalid MXID format")]
+    public string UserId { get; set; } = string.Empty;
+
+    [Required]
+    [MinLength(8, ErrorMessage = "Password must be at least 8 characters")]
+    public string Password { get; set; } = string.Empty;
+
+    public string? DisplayName { get; set; }
+    
+    public bool Admin { get; set; }
+    
+    public bool Deactivated { get; set; }
+}

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -155,7 +155,7 @@
     <value>Anzeigename</value>
   </data>
   <data name="Admin" xml:space="preserve">
-    <value>Admin</value>
+    <value>Administrator</value>
   </data>
   <data name="Guest" xml:space="preserve">
     <value>Gast</value>
@@ -705,5 +705,17 @@
   </data>
   <data name="NoRemoteMedia" xml:space="preserve">
     <value>Keine entfernten Medien in diesem Raum gefunden.</value>
+  </data>
+  <data name="UserCreatedSuccessfully" xml:space="preserve">
+    <value>Benutzer erfolgreich erstellt.</value>
+  </data>
+  <data name="ErrorCreatingUser" xml:space="preserve">
+    <value>Fehler beim Erstellen des Benutzers.</value>
+  </data>
+  <data name="CreateUser" xml:space="preserve">
+    <value>Benutzer erstellen</value>
+  </data>
+  <data name="RegisterUser" xml:space="preserve">
+    <value>Benutzer registrieren</value>
   </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -155,7 +155,7 @@
     <value>Nom d'affichage</value>
   </data>
   <data name="Admin" xml:space="preserve">
-    <value>Admin</value>
+    <value>Administrateur</value>
   </data>
   <data name="Guest" xml:space="preserve">
     <value>Invité</value>
@@ -705,5 +705,17 @@
   </data>
   <data name="NoRemoteMedia" xml:space="preserve">
     <value>Aucun média distant trouvé dans ce salon.</value>
+  </data>
+  <data name="UserCreatedSuccessfully" xml:space="preserve">
+    <value>Utilisateur créé avec succès.</value>
+  </data>
+  <data name="ErrorCreatingUser" xml:space="preserve">
+    <value>Erreur lors de la création de l'utilisateur.</value>
+  </data>
+  <data name="CreateUser" xml:space="preserve">
+    <value>Créer un utilisateur</value>
+  </data>
+  <data name="RegisterUser" xml:space="preserve">
+    <value>Enregistrer l'utilisateur</value>
   </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -98,8 +98,21 @@
     <value>About</value>
   </data>
   <data name="LoginTitle" xml:space="preserve">
-    <value>Login to Matrix Homeserver</value>
+    <value>Login to your Matrix Homeserver</value>
   </data>
+  <data name="UserCreatedSuccessfully" xml:space="preserve">
+    <value>User created successfully.</value>
+  </data>
+  <data name="ErrorCreatingUser" xml:space="preserve">
+    <value>Error creating user.</value>
+  </data>
+  <data name="CreateUser" xml:space="preserve">
+    <value>Create User</value>
+  </data>
+  <data name="RegisterUser" xml:space="preserve">
+    <value>Register User</value>
+  </data>
+
   <data name="HomeserverUrl" xml:space="preserve">
     <value>Homeserver URL</value>
   </data>

--- a/src/SynapseAdmin/Services/UserService.cs
+++ b/src/SynapseAdmin/Services/UserService.cs
@@ -2,6 +2,7 @@ using LibMatrix.Homeservers;
 using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
 using LibMatrix.EventTypes.Spec;
 using SynapseAdmin.Models.ViewModels;
+using SynapseAdmin.Models.Requests;
 using SynapseAdmin.Extensions;
 using SynapseAdmin.Interfaces;
 using SynapseAdmin.Models;
@@ -186,6 +187,37 @@ public class UserService(IMatrixSessionService sessionService, ILogger<UserServi
         {
             logger.LogError(ex, "Error fetching top media users");
             return OperationResult<List<UserMediaStatisticsViewModel>>.Failure(L["ErrorFetchingTopMediaUsers"]);
+        }
+    }
+
+    public async Task<OperationResult> CreateUserAsync(UserCreateViewModel model)
+    {
+        if (SynapseAdmin == null) return OperationResult.Failure(L["NotAuthenticated"]);
+
+        try
+        {
+            var encodedUserId = Uri.EscapeDataString(model.UserId);
+            var req = new SynapseAdminUserUpsertRequest
+            {
+                Password = model.Password,
+                DisplayName = model.DisplayName,
+                Admin = model.Admin,
+                Deactivated = model.Deactivated
+            };
+
+            var response = await SynapseAdmin.ClientHttpClient.PutAsJsonAsync($"/_synapse/admin/v2/users/{encodedUserId}", req);
+            response.EnsureSuccessStatusCode();
+            var result = await response.Content.ReadFromJsonAsync<SynapseAdminUserListResult.SynapseAdminUserListResultUser>();
+            
+            if (result == null) return OperationResult.Failure(L["ErrorCreatingUser"]);
+
+            logger.LogInformation("Successfully created user {UserId}", model.UserId.SanitizeForLogging());
+            return OperationResult.Ok(L["UserCreatedSuccessfully"]);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error creating user {UserId}", model.UserId.SanitizeForLogging());
+            return OperationResult.Failure(L["ErrorCreatingUser"]);
         }
     }
 }


### PR DESCRIPTION
This PR implements the ability for administrators to create new users on the Synapse homeserver.

Key changes:
- Added  for validation.
- Added  model for the Admin API.
- Implemented  in .
- Added  component.
- Updated the  page with a 'Create User' button.

Resolves #131