### PR TITLE
feat: add room messages to Room Details page (#133)

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -83,6 +83,53 @@ else
     </MudGrid>
 
     <MudTabs Class="mt-6" Elevation="3" Rounded="true" ApplyEffectsToContainer="true">
+        <MudTabPanel Text="@L["Messages"]" Icon="@Icons.Material.Filled.Message">
+            <MudToolBar Dense="true" Class="px-2">
+                <MudButton StartIcon="@Icons.Material.Filled.Refresh" OnClick="() => LoadMessages()" Disabled="loadingMessages" Variant="Variant.Text">@L["Refresh"]</MudButton>
+                <MudSpacer />
+                @if (messages?.EndToken != null)
+                {
+                    <MudButton EndIcon="@Icons.Material.Filled.ArrowForward" OnClick="() => LoadMessages(messages.EndToken)" Disabled="loadingMessages" Variant="Variant.Text">@L["LoadMore"]</MudButton>
+                }
+            </MudToolBar>
+            
+            @if (loadingMessages && (messages == null || messages.Messages.Count == 0))
+            {
+                <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-4" />
+            }
+            else if (messages == null || messages.Messages.Count == 0)
+            {
+                <MudAlert Severity="Severity.Info" Class="ma-4">@L["NoMessagesFound"]</MudAlert>
+            }
+            else
+            {
+                <MudTable Items="messages.Messages" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Dense="true" Loading="loadingMessages">
+                    <HeaderContent>
+                        <MudTh>@L["Time"]</MudTh>
+                        <MudTh>@L["Sender"]</MudTh>
+                        <MudTh>@L["Content"]</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="@L["Time"]">@context.OriginServerTs.ToString("g")</MudTd>
+                        <MudTd DataLabel="@L["Sender"]"><MudText Typo="Typo.body2" Color="Color.Primary">@context.Sender</MudText></MudTd>
+                        <MudTd DataLabel="@L["Content"]">
+                            @if (!string.IsNullOrEmpty(context.Body))
+                            {
+                                <MudText Typo="Typo.body2" Style="white-space: pre-wrap; word-break: break-word;">@context.Body</MudText>
+                            }
+                            else
+                            {
+                                <pre style="max-height: 100px; max-width: 600px; overflow: auto; font-size: 0.8em; white-space: pre-wrap; font-family: monospace; color: gray;">@context.Content</pre>
+                            }
+                        </MudTd>
+                    </RowTemplate>
+                    <PagerContent>
+                        <MudTablePager />
+                    </PagerContent>
+                </MudTable>
+            }
+        </MudTabPanel>
+
         <MudTabPanel Text="@L["Members"]" Icon="@Icons.Material.Filled.People">
             <MudTable Items="room.Members" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0">
                 <HeaderContent>

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
@@ -22,10 +22,13 @@ namespace SynapseAdmin.Components.Pages
         public string RoomId { get; set; } = string.Empty;
 
         private RoomDetailViewModel? room;
+        private RoomMessagesViewModel? messages;
+        private bool loadingMessages;
 
         protected override async Task OnParametersSetAsync()
         {
             await LoadRoomDetails();
+            await LoadMessages();
         }
 
         private async Task LoadRoomDetails()
@@ -39,6 +42,21 @@ namespace SynapseAdmin.Components.Pages
             {
                 Snackbar.Add(result.Message, result.Severity);
             }
+        }
+
+        private async Task LoadMessages(string? from = null)
+        {
+            loadingMessages = true;
+            var result = await RoomService.GetRoomMessagesAsync(RoomId, from: from, limit: 50, dir: "b");
+            if (result.Success)
+            {
+                messages = result.Data;
+            }
+            else
+            {
+                Snackbar.Add(result.Message, result.Severity);
+            }
+            loadingMessages = false;
         }
 
         private async Task DeleteRoom()

--- a/src/SynapseAdmin/Interfaces/IRoomService.cs
+++ b/src/SynapseAdmin/Interfaces/IRoomService.cs
@@ -12,4 +12,5 @@ public interface IRoomService
     Task<OperationResult> QuarantineMediaAsync(string roomId);
     Task<OperationResult> BlockRoomAsync(string roomId, bool block);
     Task<OperationResult<List<RoomStatisticsViewModel>>> GetLargestRoomsAsync();
+    Task<OperationResult<RoomMessagesViewModel>> GetRoomMessagesAsync(string roomId, string? from = null, int limit = 10, string dir = "f", string? filter = null, string? to = null);
 }

--- a/src/SynapseAdmin/Models/Responses/SynapseAdminRoomMessagesResponse.cs
+++ b/src/SynapseAdmin/Models/Responses/SynapseAdminRoomMessagesResponse.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Serialization;
+
+namespace SynapseAdmin.Models.Responses;
+
+public class SynapseAdminRoomMessagesResponse
+{
+    [JsonPropertyName("chunk")]
+    public List<SynapseAdminEvent> Chunk { get; set; } = [];
+
+    [JsonPropertyName("start")]
+    public string? Start { get; set; }
+
+    [JsonPropertyName("end")]
+    public string? End { get; set; }
+
+    [JsonPropertyName("state")]
+    public List<SynapseAdminEvent> State { get; set; } = [];
+}
+
+public class SynapseAdminEvent
+{
+    [JsonPropertyName("event_id")]
+    public string EventId { get; set; } = string.Empty;
+
+    [JsonPropertyName("sender")]
+    public string Sender { get; set; } = string.Empty;
+
+    [JsonPropertyName("origin_server_ts")]
+    public long OriginServerTs { get; set; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("state_key")]
+    public string? StateKey { get; set; }
+
+    [JsonPropertyName("content")]
+    public object? Content { get; set; }
+
+    [JsonPropertyName("unsigned")]
+    public object? Unsigned { get; set; }
+}

--- a/src/SynapseAdmin/Models/ViewModels/RoomMessagesViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/RoomMessagesViewModel.cs
@@ -1,0 +1,19 @@
+namespace SynapseAdmin.Models.ViewModels;
+
+public class RoomMessagesViewModel
+{
+    public List<RoomMessageItemViewModel> Messages { get; set; } = [];
+    public string? StartToken { get; set; }
+    public string? EndToken { get; set; }
+}
+
+public class RoomMessageItemViewModel
+{
+    public string EventId { get; set; } = string.Empty;
+    public string Sender { get; set; } = string.Empty;
+    public DateTime OriginServerTs { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public string? StateKey { get; set; }
+    public string? Content { get; set; } 
+    public string? Body { get; set; }
+}

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -718,4 +718,25 @@
   <data name="RegisterUser" xml:space="preserve">
     <value>Benutzer registrieren</value>
   </data>
+  <data name="ErrorFetchingRoomMessages" xml:space="preserve">
+    <value>Fehler beim Abrufen der Raumnachrichten.</value>
+  </data>
+  <data name="RoomMessages" xml:space="preserve">
+    <value>Raumnachrichten</value>
+  </data>
+  <data name="EventId" xml:space="preserve">
+    <value>Ereignis-ID</value>
+  </data>
+  <data name="Time" xml:space="preserve">
+    <value>Zeit</value>
+  </data>
+  <data name="Messages" xml:space="preserve">
+    <value>Nachrichten</value>
+  </data>
+  <data name="LoadMore" xml:space="preserve">
+    <value>Mehr laden</value>
+  </data>
+  <data name="NoMessagesFound" xml:space="preserve">
+    <value>Keine Nachrichten gefunden.</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -718,4 +718,25 @@
   <data name="RegisterUser" xml:space="preserve">
     <value>Enregistrer l'utilisateur</value>
   </data>
+  <data name="ErrorFetchingRoomMessages" xml:space="preserve">
+    <value>Erreur lors de la récupération des messages de la salle.</value>
+  </data>
+  <data name="RoomMessages" xml:space="preserve">
+    <value>Messages de la salle</value>
+  </data>
+  <data name="EventId" xml:space="preserve">
+    <value>ID de l'événement</value>
+  </data>
+  <data name="Time" xml:space="preserve">
+    <value>Heure</value>
+  </data>
+  <data name="Messages" xml:space="preserve">
+    <value>Messages</value>
+  </data>
+  <data name="LoadMore" xml:space="preserve">
+    <value>Charger plus</value>
+  </data>
+  <data name="NoMessagesFound" xml:space="preserve">
+    <value>Aucun message trouvé.</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -113,6 +113,27 @@
     <value>Register User</value>
   </data>
 
+  <data name="ErrorFetchingRoomMessages" xml:space="preserve">
+    <value>Error fetching room messages.</value>
+  </data>
+  <data name="RoomMessages" xml:space="preserve">
+    <value>Room Messages</value>
+  </data>
+  <data name="Messages" xml:space="preserve">
+    <value>Messages</value>
+  </data>
+  <data name="LoadMore" xml:space="preserve">
+    <value>Load More</value>
+  </data>
+  <data name="NoMessagesFound" xml:space="preserve">
+    <value>No messages found.</value>
+  </data>
+  <data name="EventId" xml:space="preserve">
+    <value>Event ID</value>
+  </data>
+  <data name="Time" xml:space="preserve">
+    <value>Time</value>
+  </data>
   <data name="HomeserverUrl" xml:space="preserve">
     <value>Homeserver URL</value>
   </data>

--- a/src/SynapseAdmin/Services/RoomService.cs
+++ b/src/SynapseAdmin/Services/RoomService.cs
@@ -5,10 +5,12 @@ using LibMatrix.EventTypes.Spec.State.RoomInfo;
 using SynapseAdmin.Models.ViewModels;
 using SynapseAdmin.Interfaces;
 using SynapseAdmin.Models;
+using SynapseAdmin.Models.Responses;
 using SynapseAdmin.Resources;
 using Microsoft.Extensions.Localization;
 using MudBlazor;
 using SynapseAdmin.Extensions;
+using System.Text.Json;
 
 namespace SynapseAdmin.Services;
 
@@ -220,6 +222,57 @@ public class RoomService(IMatrixSessionService sessionService, ILogger<RoomServi
         {
             logger.LogError(ex, "Error fetching largest rooms");
             return OperationResult<List<RoomStatisticsViewModel>>.Failure(L["ErrorFetchingLargestRooms"]);
+        }
+    }
+
+    public async Task<OperationResult<RoomMessagesViewModel>> GetRoomMessagesAsync(string roomId, string? from = null, int limit = 10, string dir = "f", string? filter = null, string? to = null)
+    {
+        if (SynapseAdmin == null) return OperationResult<RoomMessagesViewModel>.Failure(L["NotAuthenticated"]);
+
+        try
+        {
+            var url = $"/_synapse/admin/v1/rooms/{Uri.EscapeDataString(roomId)}/messages?limit={limit}&dir={dir}";
+            if (!string.IsNullOrEmpty(from)) url += $"&from={Uri.EscapeDataString(from)}";
+            if (!string.IsNullOrEmpty(to)) url += $"&to={Uri.EscapeDataString(to)}";
+            if (!string.IsNullOrEmpty(filter)) url += $"&filter={Uri.EscapeDataString(filter)}";
+
+            var result = await SynapseAdmin.ClientHttpClient.GetFromJsonAsync<SynapseAdminRoomMessagesResponse>(url);
+            if (result == null) return OperationResult<RoomMessagesViewModel>.Ok(new RoomMessagesViewModel());
+
+            var vm = new RoomMessagesViewModel
+            {
+                StartToken = result.Start,
+                EndToken = result.End,
+                Messages = result.Chunk
+                    .Where(m => m.Type == "m.room.message")
+                    .Select(m =>
+                    {
+                        var contentJson = JsonSerializer.SerializeToElement(m.Content);
+                        string? body = null;
+                        if (contentJson.ValueKind == JsonValueKind.Object && contentJson.TryGetProperty("body", out var bodyProp))
+                        {
+                            body = bodyProp.GetString();
+                        }
+
+                        return new RoomMessageItemViewModel
+                        {
+                            EventId = m.EventId,
+                            Sender = m.Sender,
+                            OriginServerTs = DateTimeOffset.FromUnixTimeMilliseconds(m.OriginServerTs).DateTime,
+                            Type = m.Type,
+                            StateKey = m.StateKey,
+                            Content = JsonSerializer.Serialize(m.Content),
+                            Body = body
+                        };
+                    }).ToList()
+            };
+
+            return OperationResult<RoomMessagesViewModel>.Ok(vm);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error fetching room messages for {RoomId}", roomId.SanitizeForLogging());
+            return OperationResult<RoomMessagesViewModel>.Failure(L["ErrorFetchingRoomMessages"]);
         }
     }
 }


### PR DESCRIPTION
This PR adds a new 'Messages' tab to the Room Details page, allowing admins to view the room's message history using the Synapse Admin API.

Key features:
- Fetches messages via GET /_synapse/admin/v1/rooms/<room_id>/messages.
- Filters for m.room.message events.
- Securely displays the body of messages.
- Supports token-based pagination (Load More).

Resolves #133