### PR TITLE
feat: add room memberships to User Details page (#135)

### DIFF
--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor
@@ -90,6 +90,35 @@ else
     </MudGrid>
 
     <MudTabs Class="mt-6" Elevation="3" Rounded="true" ApplyEffectsToContainer="true">
+        <MudTabPanel Text="@L["Rooms"]" Icon="@Icons.Material.Filled.MeetingRoom">
+            <MudTable Items="user.Memberships" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0">
+                <HeaderContent>
+                    <MudTh>@L["RoomId"]</MudTh>
+                    <MudTh>@L["Membership"]</MudTh>
+                    <MudTh>@L["Actions"]</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="@L["RoomId"]">@context.RoomId</MudTd>
+                    <MudTd DataLabel="@L["Membership"]">
+                        <MudChip T="string" Size="Size.Small" Variant="Variant.Text" 
+                                 Color="@(context.Membership == "join" ? Color.Success : context.Membership == "invite" ? Color.Info : Color.Default)">
+                            @context.Membership
+                        </MudChip>
+                    </MudTd>
+                    <MudTd DataLabel="@L["Actions"]">
+                        <MudButton Href="@($"/rooms/{Uri.EscapeDataString(context.RoomId)}")"
+                                   Variant="Variant.Text"
+                                   Color="Color.Primary">
+                            @L["Details"]
+                        </MudButton>
+                    </MudTd>
+                </RowTemplate>
+                <PagerContent>
+                    <MudTablePager />
+                </PagerContent>
+            </MudTable>
+        </MudTabPanel>
+
         <MudTabPanel Text="@L["Media"]" Icon="@Icons.Material.Filled.PermMedia">
              @if (user.Media == null)
             {

--- a/src/SynapseAdmin/Interfaces/IUserService.cs
+++ b/src/SynapseAdmin/Interfaces/IUserService.cs
@@ -14,4 +14,5 @@ public interface IUserService
     Task<OperationResult> SendServerNoticeAsync(string userId, string message);
     Task<OperationResult<List<UserMediaStatisticsViewModel>>> GetTopMediaUsersAsync(int count = 10);
     Task<OperationResult> CreateUserAsync(UserCreateViewModel model);
+    Task<OperationResult<List<UserMembershipViewModel>>> GetUserMembershipsAsync(string userId);
 }

--- a/src/SynapseAdmin/Models/Responses/SynapseAdminUserMembershipsResponse.cs
+++ b/src/SynapseAdmin/Models/Responses/SynapseAdminUserMembershipsResponse.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace SynapseAdmin.Models.Responses;
+
+public class SynapseAdminUserMembershipsResponse
+{
+    [JsonPropertyName("memberships")]
+    public Dictionary<string, string> Memberships { get; set; } = [];
+}

--- a/src/SynapseAdmin/Models/ViewModels/UserDetailViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/UserDetailViewModel.cs
@@ -19,6 +19,13 @@ public class UserDetailViewModel
     // Threepids, external ids etc could be added here as flattened properties or specific VMs
     
     public UserMediaViewModel? Media { get; set; }
+    public List<UserMembershipViewModel> Memberships { get; set; } = [];
+}
+
+public class UserMembershipViewModel
+{
+    public string RoomId { get; set; } = string.Empty;
+    public string Membership { get; set; } = string.Empty;
 }
 
 public class UserMediaViewModel

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -739,4 +739,10 @@
   <data name="NoMessagesFound" xml:space="preserve">
     <value>Keine Nachrichten gefunden.</value>
   </data>
+  <data name="ErrorFetchingUserMemberships" xml:space="preserve">
+    <value>Fehler beim Abrufen der Raummitgliedschaften des Benutzers.</value>
+  </data>
+  <data name="Membership" xml:space="preserve">
+    <value>Mitgliedschaft</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -739,4 +739,10 @@
   <data name="NoMessagesFound" xml:space="preserve">
     <value>Aucun message trouvé.</value>
   </data>
+  <data name="ErrorFetchingUserMemberships" xml:space="preserve">
+    <value>Erreur lors de la récupération des adhésions aux salons de l'utilisateur.</value>
+  </data>
+  <data name="Membership" xml:space="preserve">
+    <value>Adhésion</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -209,6 +209,9 @@
   <data name="Status" xml:space="preserve">
     <value>Status</value>
   </data>
+  <data name="Membership" xml:space="preserve">
+    <value>Membership</value>
+  </data>
   <data name="Active" xml:space="preserve">
     <value>Active</value>
   </data>
@@ -562,6 +565,9 @@
   </data>
   <data name="UserNotFound" xml:space="preserve">
     <value>User not found.</value>
+  </data>
+  <data name="ErrorFetchingUserMemberships" xml:space="preserve">
+    <value>Error fetching memberships for user.</value>
   </data>
   <data name="ErrorFetchingUserDetails" xml:space="preserve">
     <value>Error fetching user details.</value>

--- a/src/SynapseAdmin/Services/UserService.cs
+++ b/src/SynapseAdmin/Services/UserService.cs
@@ -3,12 +3,14 @@ using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
 using LibMatrix.EventTypes.Spec;
 using SynapseAdmin.Models.ViewModels;
 using SynapseAdmin.Models.Requests;
+using SynapseAdmin.Models.Responses;
 using SynapseAdmin.Extensions;
 using SynapseAdmin.Interfaces;
 using SynapseAdmin.Models;
 using SynapseAdmin.Resources;
 using Microsoft.Extensions.Localization;
 using MudBlazor;
+using System.Net.Http.Json;
 
 namespace SynapseAdmin.Services;
 
@@ -61,7 +63,13 @@ public class UserService(IMatrixSessionService sessionService, ILogger<UserServi
             
             if (u == null) return OperationResult<UserDetailViewModel>.Failure(L["UserNotFound"]);
 
-            var mediaResult = await SynapseAdmin.Admin.GetUserMediaAsync(userId);
+            var mediaTask = SynapseAdmin.Admin.GetUserMediaAsync(userId);
+            var membershipsTask = GetUserMembershipsAsync(userId);
+
+            await Task.WhenAll(mediaTask, membershipsTask);
+
+            var mediaResult = await mediaTask;
+            var membershipsResult = await membershipsTask;
 
             var vm = new UserDetailViewModel
             {
@@ -88,7 +96,8 @@ public class UserService(IMatrixSessionService sessionService, ILogger<UserServi
                         MediaLength = m.MediaLength,
                         CreatedTimestamp = m.CreatedTimestamp
                     }).ToList()
-                }
+                },
+                Memberships = membershipsResult.Success ? (membershipsResult.Data ?? []) : []
             };
             return OperationResult<UserDetailViewModel>.Ok(vm);
         }
@@ -218,6 +227,32 @@ public class UserService(IMatrixSessionService sessionService, ILogger<UserServi
         {
             logger.LogError(ex, "Error creating user {UserId}", model.UserId.SanitizeForLogging());
             return OperationResult.Failure(L["ErrorCreatingUser"]);
+        }
+    }
+
+    public async Task<OperationResult<List<UserMembershipViewModel>>> GetUserMembershipsAsync(string userId)
+    {
+        if (SynapseAdmin == null) return OperationResult<List<UserMembershipViewModel>>.Failure(L["NotAuthenticated"]);
+
+        try
+        {
+            var encodedUserId = Uri.EscapeDataString(userId);
+            var result = await SynapseAdmin.ClientHttpClient.GetFromJsonAsync<SynapseAdminUserMembershipsResponse>($"/_synapse/admin/v1/users/{encodedUserId}/memberships");
+            
+            if (result == null) return OperationResult<List<UserMembershipViewModel>>.Ok([]);
+
+            var vms = result.Memberships.Select(kvp => new UserMembershipViewModel
+            {
+                RoomId = kvp.Key,
+                Membership = kvp.Value
+            }).ToList();
+
+            return OperationResult<List<UserMembershipViewModel>>.Ok(vms);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error fetching memberships for user {UserId}", userId.SanitizeForLogging());
+            return OperationResult<List<UserMembershipViewModel>>.Failure(L["ErrorFetchingUserMemberships"]);
         }
     }
 }


### PR DESCRIPTION
This PR implements fetching and displaying a user's room memberships on their details page.

Key changes:
- Integrated  API.
- Added  model.
- Updated  to include membership status.
- Added a new 'Rooms' tab to the User Details page with membership state visualization.

Resolves #135