### PR TITLE
feat: append room messages when loading more (#137)

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
@@ -48,11 +48,19 @@ namespace SynapseAdmin.Components.Pages
         {
             loadingMessages = true;
             var result = await RoomService.GetRoomMessagesAsync(RoomId, from: from, limit: 50, dir: "b");
-            if (result.Success)
+            if (result.Success && result.Data != null)
             {
-                messages = result.Data;
+                if (from == null || messages == null)
+                {
+                    messages = result.Data;
+                }
+                else
+                {
+                    messages.Messages.AddRange(result.Data.Messages);
+                    messages.EndToken = result.Data.EndToken;
+                }
             }
-            else
+            else if (!result.Success)
             {
                 Snackbar.Add(result.Message, result.Severity);
             }


### PR DESCRIPTION
This PR improves the room message history UI by appending newly loaded messages to the existing list instead of replacing it.

Key changes:
- Updated  in  to concatenate new messages to the existing  list.
- Updated  to the latest token to support continuous pagination.
- Maintained 'Refresh' functionality to reset the list to the latest 50 messages.

Resolves #137