### PR TITLE
fix: resolve avatar loading (ORB blocking) on user details page

### DIFF
--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor
@@ -33,7 +33,14 @@ else
                         @if (!string.IsNullOrEmpty(user.AvatarUrl))
                         {
                             <MudAvatar Size="Size.Large" Class="mr-4">
-                                <MudImage Src="@(user.AvatarUrl.StartsWith("mxc://") ? $"{MatrixSession.AuthenticatedHomeserver.WellKnownUris.Client}/_matrix/media/v3/download/{user.AvatarUrl.Substring(6)}" : user.AvatarUrl)" />
+                                @if (user.AvatarData != null)
+                                {
+                                    <MudImage Src="@($"data:image/jpeg;base64,{Convert.ToBase64String(user.AvatarData)}")" />
+                                }
+                                else
+                                {
+                                    <MudImage Src="@(user.AvatarUrl.StartsWith("mxc://") ? $"/api/Media/avatar?mxc={Uri.EscapeDataString(user.AvatarUrl)}" : user.AvatarUrl)" />
+                                }
                             </MudAvatar>
                         }
                         else

--- a/src/SynapseAdmin/Models/ViewModels/UserDetailViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/UserDetailViewModel.cs
@@ -5,6 +5,7 @@ public class UserDetailViewModel
     public string UserId { get; set; } = string.Empty;
     public string? DisplayName { get; set; }
     public string? AvatarUrl { get; set; }
+    public byte[]? AvatarData { get; set; }
     public bool Deactivated { get; set; }
     public bool Admin { get; set; }
     public long CreationTs { get; set; }

--- a/src/SynapseAdmin/Services/UserService.cs
+++ b/src/SynapseAdmin/Services/UserService.cs
@@ -99,6 +99,35 @@ public class UserService(IMatrixSessionService sessionService, ILogger<UserServi
                 },
                 Memberships = membershipsResult.Success ? (membershipsResult.Data ?? []) : []
             };
+
+            // Fetch avatar data if available and not too large (3MB limit)
+            if (!string.IsNullOrEmpty(vm.AvatarUrl))
+            {
+                try
+                {
+                    var downloadUrl = await SynapseAdmin.GetMediaUrlAsync(vm.AvatarUrl);
+                    using var response = await SynapseAdmin.ClientHttpClient.GetAsync(downloadUrl);
+                    response.EnsureSuccessStatusCode();
+
+                    var contentLength = response.Content.Headers.ContentLength;
+                    if (contentLength is null or <= 3 * 1024 * 1024)
+                    {
+                        var stream = await response.Content.ReadAsStreamAsync();
+                        using var ms = new MemoryStream();
+                        await stream.CopyToAsync(ms);
+                        vm.AvatarData = ms.ToArray();
+                    }
+                    else
+                    {
+                        logger.LogWarning("Avatar for user {UserId} is too large ({Size} bytes), skipping embed", userId.SanitizeForLogging(), contentLength);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to fetch avatar data for user {UserId}", userId.SanitizeForLogging());
+                }
+            }
+
             return OperationResult<UserDetailViewModel>.Ok(vm);
         }
         catch (Exception ex)


### PR DESCRIPTION
Resolves #144. This PR implements server-side avatar fetching in the UserService to bypass browser ORB blocking when authenticated media is required. The image is embedded as a base64 data URL in the UserDetailViewModel with a 3MB size limit.