### PR TITLE
feat: add filename column to user media list in UserDetails

### DIFF
--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor
@@ -137,6 +137,7 @@ else
                 <MudTable Items="user.Media.Media" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0">
                     <HeaderContent>
                         <MudTh>@L["MediaId"]</MudTh>
+                        <MudTh>@L["FileName"]</MudTh>
                         <MudTh>@L["Type"]</MudTh>
                         <MudTh>@L["Size"]</MudTh>
                         <MudTh>@L["Created"]</MudTh>
@@ -144,6 +145,7 @@ else
                     </HeaderContent>
                     <RowTemplate>
                         <MudTd DataLabel="@L["MediaId"]">@context.MediaId</MudTd>
+                        <MudTd DataLabel="@L["FileName"]">@context.UploadName</MudTd>
                         <MudTd DataLabel="@L["Type"]">@context.MediaType</MudTd>
                         <MudTd DataLabel="@L["Size"]">@(context.MediaLength / 1024) KB</MudTd>
                         <MudTd DataLabel="@L["Created"]">@DateTimeOffset.FromUnixTimeMilliseconds(context.CreatedTimestamp).DateTime.ToString("g")</MudTd>

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -199,6 +199,9 @@
   <data name="MediaId" xml:space="preserve">
     <value>Medien-ID</value>
   </data>
+  <data name="FileName" xml:space="preserve">
+    <value>Dateiname</value>
+  </data>
   <data name="Type" xml:space="preserve">
     <value>Typ</value>
   </data>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -199,6 +199,9 @@
   <data name="MediaId" xml:space="preserve">
     <value>ID média</value>
   </data>
+  <data name="FileName" xml:space="preserve">
+    <value>Nom du fichier</value>
+  </data>
   <data name="Type" xml:space="preserve">
     <value>Type</value>
   </data>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -236,6 +236,9 @@
   <data name="MediaId" xml:space="preserve">
     <value>Media ID</value>
   </data>
+  <data name="FileName" xml:space="preserve">
+    <value>File Name</value>
+  </data>
   <data name="Type" xml:space="preserve">
     <value>Type</value>
   </data>


### PR DESCRIPTION
Resolves #160. Added filename column to the media tab in UserDetails page.