### PR TITLE
feat: add download and preview actions to room media tab

### DIFF
--- a/src/SynapseAdmin/Components/Layout/MainLayout.razor.cs
+++ b/src/SynapseAdmin/Components/Layout/MainLayout.razor.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using Microsoft.AspNetCore.Components;
-using MudBlazor;
 using SynapseAdmin.Interfaces;
 
 namespace SynapseAdmin.Components.Layout;

--- a/src/SynapseAdmin/Components/Pages/Home.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/Home.razor.cs
@@ -1,9 +1,7 @@
 using LibMatrix.Homeservers;
 using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.Localization;
 using SynapseAdmin.Interfaces;
 using SynapseAdmin.Models.ViewModels;
-using SynapseAdmin.Resources;
 using SynapseAdmin.Extensions;
 using MudBlazor;
 

--- a/src/SynapseAdmin/Components/Pages/Login.razor
+++ b/src/SynapseAdmin/Components/Pages/Login.razor
@@ -1,7 +1,5 @@
 @page "/login"
 @using SynapseAdmin.Models.ViewModels
-@using SynapseAdmin.Services
-@using Microsoft.AspNetCore.Components.Authorization
 
 <PageTitle>@L["Login"] - SynapseAdmin.NET</PageTitle>
 

--- a/src/SynapseAdmin/Components/Pages/MediaPreviewDialog.razor
+++ b/src/SynapseAdmin/Components/Pages/MediaPreviewDialog.razor
@@ -1,4 +1,3 @@
-@using SynapseAdmin.Resources
 @inject IStringLocalizer<SharedResources> L
 
 <MudDialog>

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -181,9 +181,33 @@ else
                     <MudTable Items="room.Media.Local" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Class="mb-6">
                         <HeaderContent>
                             <MudTh>@L["MediaId"]</MudTh>
+                            <MudTh>@L["FileName"]</MudTh>
+                            <MudTh>@L["Type"]</MudTh>
+                            <MudTh>@L["Size"]</MudTh>
+                            <MudTh>@L["Actions"]</MudTh>
                         </HeaderContent>
                         <RowTemplate>
                             <MudTd DataLabel="@L["MediaId"]">@context.MediaId</MudTd>
+                            <MudTd DataLabel="@L["FileName"]">@context.UploadName</MudTd>
+                            <MudTd DataLabel="@L["Type"]">@context.MediaType</MudTd>
+                            <MudTd DataLabel="@L["Size"]">@(context.MediaLength > 0 ? $"{(context.MediaLength / 1024)} KB" : "")</MudTd>
+                            <MudTd DataLabel="@L["Actions"]">
+                                <div class="d-flex">
+                                    <MudIconButton Icon="@Icons.Material.Filled.Download" 
+                                                   Color="Color.Primary" 
+                                                   Href="@($"/Media/Download?mxc={Uri.EscapeDataString(context.MediaId)}")"
+                                                   Target="_blank"
+                                                   title="@L["Download"]" />
+                                    
+                                    @if (IsPreviewable(context.MediaType))
+                                    {
+                                        <MudIconButton Icon="@Icons.Material.Filled.Visibility" 
+                                                       Color="Color.Secondary" 
+                                                       OnClick="@(() => ShowPreview(context))"
+                                                       title="@L["Preview"]" />
+                                    }
+                                </div>
+                            </MudTd>
                         </RowTemplate>
                         <PagerContent>
                             <MudTablePager />
@@ -201,9 +225,33 @@ else
                     <MudTable Items="room.Media.Remote" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0">
                         <HeaderContent>
                             <MudTh>@L["MediaId"]</MudTh>
+                            <MudTh>@L["FileName"]</MudTh>
+                            <MudTh>@L["Type"]</MudTh>
+                            <MudTh>@L["Size"]</MudTh>
+                            <MudTh>@L["Actions"]</MudTh>
                         </HeaderContent>
                         <RowTemplate>
                             <MudTd DataLabel="@L["MediaId"]">@context.MediaId</MudTd>
+                            <MudTd DataLabel="@L["FileName"]">@context.UploadName</MudTd>
+                            <MudTd DataLabel="@L["Type"]">@context.MediaType</MudTd>
+                            <MudTd DataLabel="@L["Size"]">@(context.MediaLength > 0 ? $"{(context.MediaLength / 1024)} KB" : "")</MudTd>
+                            <MudTd DataLabel="@L["Actions"]">
+                                <div class="d-flex">
+                                    <MudIconButton Icon="@Icons.Material.Filled.Download" 
+                                                   Color="Color.Primary" 
+                                                   Href="@($"/Media/Download?mxc={Uri.EscapeDataString(context.MediaId)}")"
+                                                   Target="_blank"
+                                                   title="@L["Download"]" />
+                                    
+                                    @if (IsPreviewable(context.MediaType))
+                                    {
+                                        <MudIconButton Icon="@Icons.Material.Filled.Visibility" 
+                                                       Color="Color.Secondary" 
+                                                       OnClick="@(() => ShowPreview(context))"
+                                                       title="@L["Preview"]" />
+                                    }
+                                </div>
+                            </MudTd>
                         </RowTemplate>
                         <PagerContent>
                             <MudTablePager />

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -1,6 +1,7 @@
 @page "/rooms/{RoomId}"
 @using LibMatrix.Homeservers
 @using Microsoft.AspNetCore.Authorization
+@using SynapseAdmin.Models.ViewModels
 
 @attribute [Authorize]
 
@@ -178,7 +179,7 @@ else
                 }
                 else
                 {
-                    <MudTable Items="room.Media.Local" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Class="mb-6">
+                    <MudTable T="RoomMediaItemViewModel" ServerData="LoadLocalMedia" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Class="mb-6" RowsPerPage="10">
                         <HeaderContent>
                             <MudTh>@L["MediaId"]</MudTh>
                             <MudTh>@L["FileName"]</MudTh>
@@ -222,7 +223,7 @@ else
                 }
                 else
                 {
-                    <MudTable Items="room.Media.Remote" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0">
+                    <MudTable T="RoomMediaItemViewModel" ServerData="LoadRemoteMedia" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" RowsPerPage="10">
                         <HeaderContent>
                             <MudTh>@L["MediaId"]</MudTh>
                             <MudTh>@L["FileName"]</MudTh>

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
@@ -114,5 +114,33 @@ namespace SynapseAdmin.Components.Pages
             var result = await RoomService.BlockRoomAsync(RoomId, true);
             Snackbar.Add(result.Message, result.Severity);
         }
+
+        private bool IsPreviewable(string? mimeType)
+        {
+            if (string.IsNullOrEmpty(mimeType))
+            {
+                // For room media we often don't have the mime type upfront. 
+                // We'll allow previewing by default if it's missing, 
+                // the preview dialog handles the error if it's not actually an image/video/audio.
+                return true; 
+            }
+            return mimeType.StartsWith("image/") || mimeType.StartsWith("video/") || mimeType.StartsWith("audio/");
+        }
+
+        private async Task ShowPreview(RoomMediaItemViewModel media)
+        {
+            var mxc = media.MediaId;
+            var previewUrl = $"/Media/Preview?mxc={Uri.EscapeDataString(mxc)}&mimeType={Uri.EscapeDataString(media.MediaType ?? "")}";
+            
+            var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
+            var parameters = new DialogParameters
+            {
+                { "Title", media.UploadName ?? media.MediaId },
+                { "PreviewUrl", previewUrl },
+                { "MediaType", media.MediaType }
+            };
+
+            await DialogService.ShowAsync<MediaPreviewDialog>(media.UploadName ?? L["MediaPreview"], parameters, options);
+        }
     }
 }

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
@@ -44,6 +44,44 @@ namespace SynapseAdmin.Components.Pages
             }
         }
 
+        private async Task<TableData<RoomMediaItemViewModel>> LoadLocalMedia(TableState state, CancellationToken token)
+        {
+            if (room?.Media?.Local == null) return new TableData<RoomMediaItemViewModel> { TotalItems = 0, Items = [] };
+
+            var uris = room.Media.Local.Select(m => m.MediaId).Skip(state.Page * state.PageSize).Take(state.PageSize).ToList();
+            if (uris.Count == 0) return new TableData<RoomMediaItemViewModel> { TotalItems = room.Media.Local.Count, Items = [] };
+
+            var result = await RoomService.GetMediaMetadataBatchAsync(uris);
+            if (result.Success)
+            {
+                return new TableData<RoomMediaItemViewModel> { TotalItems = room.Media.Local.Count, Items = result.Data };
+            }
+            else
+            {
+                Snackbar.Add(result.Message, result.Severity);
+                return new TableData<RoomMediaItemViewModel> { TotalItems = room.Media.Local.Count, Items = [] };
+            }
+        }
+
+        private async Task<TableData<RoomMediaItemViewModel>> LoadRemoteMedia(TableState state, CancellationToken token)
+        {
+            if (room?.Media?.Remote == null) return new TableData<RoomMediaItemViewModel> { TotalItems = 0, Items = [] };
+
+            var uris = room.Media.Remote.Select(m => m.MediaId).Skip(state.Page * state.PageSize).Take(state.PageSize).ToList();
+            if (uris.Count == 0) return new TableData<RoomMediaItemViewModel> { TotalItems = room.Media.Remote.Count, Items = [] };
+
+            var result = await RoomService.GetMediaMetadataBatchAsync(uris);
+            if (result.Success)
+            {
+                return new TableData<RoomMediaItemViewModel> { TotalItems = room.Media.Remote.Count, Items = result.Data };
+            }
+            else
+            {
+                Snackbar.Add(result.Message, result.Severity);
+                return new TableData<RoomMediaItemViewModel> { TotalItems = room.Media.Remote.Count, Items = [] };
+            }
+        }
+
         private async Task LoadMessages(string? from = null)
         {
             loadingMessages = true;

--- a/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor
+++ b/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor
@@ -1,6 +1,3 @@
-@using SynapseAdmin.Models.ViewModels
-@using SynapseAdmin.Interfaces
-
 <MudDialog>
     <TitleContent>
         <MudText Typo="Typo.h6">

--- a/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor.cs
@@ -2,8 +2,6 @@ using Microsoft.AspNetCore.Components;
 using MudBlazor;
 using SynapseAdmin.Interfaces;
 using SynapseAdmin.Models.ViewModels;
-using SynapseAdmin.Resources;
-using Microsoft.Extensions.Localization;
 
 namespace SynapseAdmin.Components.Pages;
 

--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor
@@ -1,7 +1,6 @@
 @page "/users/{UserId}"
 @using LibMatrix.Homeservers
 @using Microsoft.AspNetCore.Authorization
-@using SynapseAdmin.Models.ViewModels
 
 @attribute [Authorize]
 

--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor
@@ -176,26 +176,3 @@ else
     </MudTabs>
 }
 
-@code {
-    private bool IsPreviewable(string? mimeType)
-    {
-        if (string.IsNullOrEmpty(mimeType)) return false;
-        return mimeType.StartsWith("image/") || mimeType.StartsWith("video/") || mimeType.StartsWith("audio/");
-    }
-
-    private async Task ShowPreview(UserMediaItemViewModel media)
-    {
-        var mxc = $"mxc://{MatrixSession.AuthenticatedHomeserver!.ServerName}/{media.MediaId}";
-        var previewUrl = $"/Media/Preview?mxc={Uri.EscapeDataString(mxc)}&mimeType={Uri.EscapeDataString(media.MediaType ?? "")}";
-        
-        var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
-        var parameters = new DialogParameters
-        {
-            { "Title", media.UploadName ?? media.MediaId },
-            { "PreviewUrl", previewUrl },
-            { "MediaType", media.MediaType }
-        };
-
-        await DialogService.ShowAsync<MediaPreviewDialog>(media.UploadName ?? L["MediaPreview"], parameters, options);
-    }
-}

--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor.cs
@@ -78,5 +78,27 @@ namespace SynapseAdmin.Components.Pages
             var result = await UserService.LoginAsUserAsync(UserId, TimeSpan.FromHours(1));
             Snackbar.Add(result.Message, result.Severity);
         }
+
+        private bool IsPreviewable(string? mimeType)
+        {
+            if (string.IsNullOrEmpty(mimeType)) return false;
+            return mimeType.StartsWith("image/") || mimeType.StartsWith("video/") || mimeType.StartsWith("audio/");
+        }
+
+        private async Task ShowPreview(UserMediaItemViewModel media)
+        {
+            var mxc = $"mxc://{MatrixSession.AuthenticatedHomeserver!.ServerName}/{media.MediaId}";
+            var previewUrl = $"/Media/Preview?mxc={Uri.EscapeDataString(mxc)}&mimeType={Uri.EscapeDataString(media.MediaType ?? "")}";
+
+            var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
+            var parameters = new DialogParameters
+            {
+                { "Title", media.UploadName ?? media.MediaId },
+                { "PreviewUrl", previewUrl },
+                { "MediaType", media.MediaType }
+            };
+
+            await DialogService.ShowAsync<MediaPreviewDialog>(media.UploadName ?? L["MediaPreview"], parameters, options);
+        }
     }
 }

--- a/src/SynapseAdmin/Components/Pages/Users.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/Users.razor.cs
@@ -1,9 +1,7 @@
 using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.Localization;
 using MudBlazor;
 using SynapseAdmin.Models.ViewModels;
 using SynapseAdmin.Interfaces;
-using SynapseAdmin.Resources;
 
 namespace SynapseAdmin.Components.Pages
 {

--- a/src/SynapseAdmin/Extensions/AuthenticatedHomeserverSynapseExtensions.cs
+++ b/src/SynapseAdmin/Extensions/AuthenticatedHomeserverSynapseExtensions.cs
@@ -1,5 +1,7 @@
 using System.Net.Http.Json;
 using LibMatrix.Homeservers;
+using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
+using LibMatrix.StructuredData;
 using SynapseAdmin.Models.Requests;
 using SynapseAdmin.Models.Responses;
 
@@ -7,6 +9,17 @@ namespace SynapseAdmin.Extensions;
 
 public static class AuthenticatedHomeserverSynapseExtensions
 {
+    public static async Task<SynapseAdminUserMediaResult.MediaInfo?> GetMediaMetadataAsync(this AuthenticatedHomeserverSynapse homeserver, string serverName, string mediaId)
+    {
+        return await homeserver.ClientHttpClient.GetFromJsonAsync<SynapseAdminUserMediaResult.MediaInfo>(
+            $"/_synapse/admin/v1/media/{serverName}/{mediaId}");
+    }
+
+    public static async Task<SynapseAdminUserMediaResult.MediaInfo?> GetMediaMetadataAsync(this AuthenticatedHomeserverSynapse homeserver, MxcUri mxcUri)
+    {
+        return await homeserver.GetMediaMetadataAsync(mxcUri.ServerName, mxcUri.MediaId);
+    }
+
     public static async Task<SendServerNoticeResponse?> SendServerNoticeAsync(
         this AuthenticatedHomeserverSynapse homeserver,
         string userId,

--- a/src/SynapseAdmin/Extensions/AuthenticatedHomeserverSynapseExtensions.cs
+++ b/src/SynapseAdmin/Extensions/AuthenticatedHomeserverSynapseExtensions.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using ArcaneLibs.Extensions;
 using LibMatrix.Homeservers;
 using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
 using LibMatrix.StructuredData;
@@ -18,6 +19,20 @@ public static class AuthenticatedHomeserverSynapseExtensions
     public static async Task<SynapseAdminUserMediaResult.MediaInfo?> GetMediaMetadataAsync(this AuthenticatedHomeserverSynapse homeserver, MxcUri mxcUri)
     {
         return await homeserver.GetMediaMetadataAsync(mxcUri.ServerName, mxcUri.MediaId);
+    }
+
+    public static async Task<SynapseAdminRoomMediaListResult?> GetRoomMediaListAsync(this AuthenticatedHomeserverSynapse homeserver, string roomId, int? limit = null, string? from = null)
+    {
+        var url = $"/_synapse/admin/v1/room/{roomId.UrlEncode()}/media";
+        // Parameters are included for future compatibility as requested
+        if (limit.HasValue || !string.IsNullOrEmpty(from))
+        {
+            var query = new List<string>();
+            if (limit.HasValue) query.Add($"limit={limit}");
+            if (!string.IsNullOrEmpty(from)) query.Add($"from={from}");
+            url += "?" + string.Join("&", query);
+        }
+        return await homeserver.ClientHttpClient.GetFromJsonAsync<SynapseAdminRoomMediaListResult>(url);
     }
 
     public static async Task<SendServerNoticeResponse?> SendServerNoticeAsync(

--- a/src/SynapseAdmin/Interfaces/IRoomService.cs
+++ b/src/SynapseAdmin/Interfaces/IRoomService.cs
@@ -13,4 +13,5 @@ public interface IRoomService
     Task<OperationResult> BlockRoomAsync(string roomId, bool block);
     Task<OperationResult<List<RoomStatisticsViewModel>>> GetLargestRoomsAsync();
     Task<OperationResult<RoomMessagesViewModel>> GetRoomMessagesAsync(string roomId, string? from = null, int limit = 10, string dir = "f", string? filter = null, string? to = null);
+    Task<OperationResult<List<RoomMediaItemViewModel>>> GetMediaMetadataBatchAsync(List<string> mxcUris);
 }

--- a/src/SynapseAdmin/Models/ViewModels/RoomDetailViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/RoomDetailViewModel.cs
@@ -45,4 +45,8 @@ public class RoomMediaViewModel
 public class RoomMediaItemViewModel
 {
     public string MediaId { get; set; } = string.Empty;
+    public string? UploadName { get; set; }
+    public string? MediaType { get; set; }
+    public long MediaLength { get; set; }
+    public long CreatedTimestamp { get; set; }
 }

--- a/src/SynapseAdmin/Services/RoomService.cs
+++ b/src/SynapseAdmin/Services/RoomService.cs
@@ -75,60 +75,13 @@ public class RoomService(IMatrixSessionService sessionService, ILogger<RoomServi
 
             var membersTask = SynapseAdmin.Admin.GetRoomMembersAsync(roomId);
             var stateTask = SynapseAdmin.Admin.GetRoomStateAsync(roomId);
-            var mediaTask = SynapseAdmin.Admin.GetRoomMediaAsync(roomId);
+            var mediaTask = SynapseAdmin.GetRoomMediaListAsync(roomId);
 
             await Task.WhenAll(membersTask, stateTask, mediaTask);
 
             var members = await membersTask;
             var stateEvents = await stateTask;
             var media = await mediaTask;
-
-            var localMediaTasks = (media?.Local ?? []).Select(async m =>
-            {
-                var vm = new RoomMediaItemViewModel { MediaId = m };
-                try
-                {
-                    var mxc = MxcUri.Parse(m);
-                    var meta = await SynapseAdmin.GetMediaMetadataAsync(mxc);
-                    if (meta != null)
-                    {
-                        vm.UploadName = meta.UploadName;
-                        vm.MediaType = meta.MediaType;
-                        vm.MediaLength = meta.MediaLength;
-                        vm.CreatedTimestamp = meta.CreatedTimestamp;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.LogDebug(ex, "Failed to fetch metadata for local media {Mxc}", m);
-                }
-                return vm;
-            });
-
-            var remoteMediaTasks = (media?.Remote ?? []).Select(async m =>
-            {
-                var vm = new RoomMediaItemViewModel { MediaId = m };
-                try
-                {
-                    var mxc = MxcUri.Parse(m);
-                    var meta = await SynapseAdmin.GetMediaMetadataAsync(mxc);
-                    if (meta != null)
-                    {
-                        vm.UploadName = meta.UploadName;
-                        vm.MediaType = meta.MediaType;
-                        vm.MediaLength = meta.MediaLength;
-                        vm.CreatedTimestamp = meta.CreatedTimestamp;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.LogDebug(ex, "Failed to fetch metadata for remote media {Mxc}", m);
-                }
-                return vm;
-            });
-
-            var localMedia = (await Task.WhenAll(localMediaTasks)).ToList();
-            var remoteMedia = (await Task.WhenAll(remoteMediaTasks)).ToList();
 
             var tombstone = stateEvents?.Events
                 .FirstOrDefault(x => x.Type == RoomTombstoneEventContent.EventId)?
@@ -164,8 +117,8 @@ public class RoomService(IMatrixSessionService sessionService, ILogger<RoomServi
                 }).ToList() ?? [],
                 Media = media == null ? null : new RoomMediaViewModel
                 {
-                    Local = localMedia,
-                    Remote = remoteMedia
+                    Local = media.Local.Select(m => new RoomMediaItemViewModel { MediaId = m }).ToList(),
+                    Remote = media.Remote.Select(m => new RoomMediaItemViewModel { MediaId = m }).ToList()
                 }
             };
             return OperationResult<RoomDetailViewModel>.Ok(vm);
@@ -174,6 +127,44 @@ public class RoomService(IMatrixSessionService sessionService, ILogger<RoomServi
         {
             logger.LogError(ex, "Error fetching room details for {RoomId}", roomId.SanitizeForLogging());
             return OperationResult<RoomDetailViewModel>.Failure(L["ErrorFetchingRoomDetails"]);
+        }
+    }
+
+    public async Task<OperationResult<List<RoomMediaItemViewModel>>> GetMediaMetadataBatchAsync(List<string> mxcUris)
+    {
+        if (SynapseAdmin == null) return OperationResult<List<RoomMediaItemViewModel>>.Failure(L["NotAuthenticated"]);
+
+        try
+        {
+            var tasks = mxcUris.Select(async m =>
+            {
+                var vm = new RoomMediaItemViewModel { MediaId = m };
+                try
+                {
+                    var mxc = MxcUri.Parse(m);
+                    var meta = await SynapseAdmin.GetMediaMetadataAsync(mxc);
+                    if (meta != null)
+                    {
+                        vm.UploadName = meta.UploadName;
+                        vm.MediaType = meta.MediaType;
+                        vm.MediaLength = meta.MediaLength;
+                        vm.CreatedTimestamp = meta.CreatedTimestamp;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogDebug(ex, "Failed to fetch metadata for media {Mxc}", m);
+                }
+                return vm;
+            });
+
+            var results = (await Task.WhenAll(tasks)).ToList();
+            return OperationResult<List<RoomMediaItemViewModel>>.Ok(results);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error fetching media metadata batch");
+            return OperationResult<List<RoomMediaItemViewModel>>.Failure(L["ErrorFetchingMedia"]);
         }
     }
 

--- a/src/SynapseAdmin/Services/RoomService.cs
+++ b/src/SynapseAdmin/Services/RoomService.cs
@@ -2,6 +2,7 @@ using LibMatrix.Homeservers;
 using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
 using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Requests;
 using LibMatrix.EventTypes.Spec.State.RoomInfo;
+using LibMatrix.StructuredData;
 using SynapseAdmin.Models.ViewModels;
 using SynapseAdmin.Interfaces;
 using SynapseAdmin.Models;
@@ -81,7 +82,54 @@ public class RoomService(IMatrixSessionService sessionService, ILogger<RoomServi
             var members = await membersTask;
             var stateEvents = await stateTask;
             var media = await mediaTask;
-            
+
+            var localMediaTasks = (media?.Local ?? []).Select(async m =>
+            {
+                var vm = new RoomMediaItemViewModel { MediaId = m };
+                try
+                {
+                    var mxc = MxcUri.Parse(m);
+                    var meta = await SynapseAdmin.GetMediaMetadataAsync(mxc);
+                    if (meta != null)
+                    {
+                        vm.UploadName = meta.UploadName;
+                        vm.MediaType = meta.MediaType;
+                        vm.MediaLength = meta.MediaLength;
+                        vm.CreatedTimestamp = meta.CreatedTimestamp;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogDebug(ex, "Failed to fetch metadata for local media {Mxc}", m);
+                }
+                return vm;
+            });
+
+            var remoteMediaTasks = (media?.Remote ?? []).Select(async m =>
+            {
+                var vm = new RoomMediaItemViewModel { MediaId = m };
+                try
+                {
+                    var mxc = MxcUri.Parse(m);
+                    var meta = await SynapseAdmin.GetMediaMetadataAsync(mxc);
+                    if (meta != null)
+                    {
+                        vm.UploadName = meta.UploadName;
+                        vm.MediaType = meta.MediaType;
+                        vm.MediaLength = meta.MediaLength;
+                        vm.CreatedTimestamp = meta.CreatedTimestamp;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogDebug(ex, "Failed to fetch metadata for remote media {Mxc}", m);
+                }
+                return vm;
+            });
+
+            var localMedia = (await Task.WhenAll(localMediaTasks)).ToList();
+            var remoteMedia = (await Task.WhenAll(remoteMediaTasks)).ToList();
+
             var tombstone = stateEvents?.Events
                 .FirstOrDefault(x => x.Type == RoomTombstoneEventContent.EventId)?
                 .ContentAs<RoomTombstoneEventContent>();
@@ -116,8 +164,8 @@ public class RoomService(IMatrixSessionService sessionService, ILogger<RoomServi
                 }).ToList() ?? [],
                 Media = media == null ? null : new RoomMediaViewModel
                 {
-                    Local = media.Local.Select(m => new RoomMediaItemViewModel { MediaId = m }).ToList(),
-                    Remote = media.Remote.Select(m => new RoomMediaItemViewModel { MediaId = m }).ToList()
+                    Local = localMedia,
+                    Remote = remoteMedia
                 }
             };
             return OperationResult<RoomDetailViewModel>.Ok(vm);


### PR DESCRIPTION
Implement the media download and preview function for the RoomDetails Media Tab, matching the functionality available on the UserDetails Media Tab.

### Changes:
- Expanded  with metadata fields.
- Added  extension method for .
- Updated  to fetch media metadata concurrently.
- Enhanced  UI to show detailed media tables with download and preview buttons.