### PR TITLE
fix: correct room media metadata deserialization

### DIFF
--- a/src/SynapseAdmin/Extensions/AuthenticatedHomeserverSynapseExtensions.cs
+++ b/src/SynapseAdmin/Extensions/AuthenticatedHomeserverSynapseExtensions.cs
@@ -12,8 +12,9 @@ public static class AuthenticatedHomeserverSynapseExtensions
 {
     public static async Task<SynapseAdminUserMediaResult.MediaInfo?> GetMediaMetadataAsync(this AuthenticatedHomeserverSynapse homeserver, string serverName, string mediaId)
     {
-        return await homeserver.ClientHttpClient.GetFromJsonAsync<SynapseAdminUserMediaResult.MediaInfo>(
+        var result = await homeserver.ClientHttpClient.GetFromJsonAsync<SynapseAdminMediaMetadataResponse>(
             $"/_synapse/admin/v1/media/{serverName}/{mediaId}");
+        return result?.MediaInfo;
     }
 
     public static async Task<SynapseAdminUserMediaResult.MediaInfo?> GetMediaMetadataAsync(this AuthenticatedHomeserverSynapse homeserver, MxcUri mxcUri)

--- a/src/SynapseAdmin/Models/Responses/SynapseAdminMediaMetadataResponse.cs
+++ b/src/SynapseAdmin/Models/Responses/SynapseAdminMediaMetadataResponse.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+using LibMatrix.Homeservers.ImplementationDetails.Synapse.Models.Responses;
+
+namespace SynapseAdmin.Models.Responses;
+
+public class SynapseAdminMediaMetadataResponse
+{
+    [JsonPropertyName("media_info")]
+    public SynapseAdminUserMediaResult.MediaInfo? MediaInfo { get; set; }
+}


### PR DESCRIPTION
Fixes the issue where room media metadata was always empty because the Synapse Admin API returns the data wrapped in a 'media_info' property. Closes #163 