### PR TITLE
fix: correct user creation date display

### DIFF
--- a/src/SynapseAdmin/Models/ViewModels/UserDetailViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/UserDetailViewModel.cs
@@ -9,7 +9,7 @@ public class UserDetailViewModel
     public bool Deactivated { get; set; }
     public bool Admin { get; set; }
     public long CreationTs { get; set; }
-    public DateTime CreationTsDateTime => DateTimeOffset.FromUnixTimeSeconds(CreationTs).DateTime;
+    public DateTime CreationTsDateTime => DateTimeOffset.FromUnixTimeMilliseconds(CreationTs).DateTime;
     public string UserType { get; set; } = string.Empty;
     public bool Locked { get; set; }
     public bool ShadowBanned { get; set; }

--- a/src/SynapseAdmin/Services/UserService.cs
+++ b/src/SynapseAdmin/Services/UserService.cs
@@ -78,7 +78,7 @@ public class UserService(IMatrixSessionService sessionService, ILogger<UserServi
                 AvatarUrl = u.AvatarUrl,
                 Deactivated = u.Deactivated,
                 Admin = u.Admin == true,
-                CreationTs = DateTimeOffset.FromUnixTimeMilliseconds(u.CreationTs).ToUnixTimeSeconds(),
+                CreationTs = u.CreationTs,
                 UserType = u.UserType ?? "user",
                 Locked = u.Locked,
                 ShadowBanned = u.ShadowBanned,


### PR DESCRIPTION
Fixes #149. User creation date was showing incorrectly due to double conversion and unit mismatch (seconds vs milliseconds).