### PR TITLE
feat: improve media download filenames and sanitize parameters

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -196,7 +196,7 @@ else
                                 <div class="d-flex">
                                     <MudIconButton Icon="@Icons.Material.Filled.Download" 
                                                    Color="Color.Primary" 
-                                                   Href="@($"/Media/Download?mxc={Uri.EscapeDataString(context.MediaId)}")"
+                                                   Href="@($"/Media/Download?mxc={Uri.EscapeDataString(context.MediaId)}&filename={Uri.EscapeDataString(context.DownloadName)}&mimeType={Uri.EscapeDataString(context.MediaType ?? "application/octet-stream")}")"
                                                    Target="_blank"
                                                    title="@L["Download"]" />
                                     
@@ -240,7 +240,7 @@ else
                                 <div class="d-flex">
                                     <MudIconButton Icon="@Icons.Material.Filled.Download" 
                                                    Color="Color.Primary" 
-                                                   Href="@($"/Media/Download?mxc={Uri.EscapeDataString(context.MediaId)}")"
+                                                   Href="@($"/Media/Download?mxc={Uri.EscapeDataString(context.MediaId)}&filename={Uri.EscapeDataString(context.DownloadName)}&mimeType={Uri.EscapeDataString(context.MediaType ?? "application/octet-stream")}")"
                                                    Target="_blank"
                                                    title="@L["Download"]" />
                                     

--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor
@@ -152,7 +152,7 @@ else
                             <div class="d-flex">
                                 <MudIconButton Icon="@Icons.Material.Filled.Download" 
                                                Color="Color.Primary" 
-                                               Href="@($"/Media/Download?mxc=mxc://{MatrixSession.AuthenticatedHomeserver!.ServerName}/{context.MediaId}")"
+                                               Href="@($"/Media/Download?mxc={Uri.EscapeDataString($"mxc://{MatrixSession.AuthenticatedHomeserver!.ServerName}/{context.MediaId}")}&filename={Uri.EscapeDataString(context.DownloadName)}&mimeType={Uri.EscapeDataString(context.MediaType ?? "application/octet-stream")}")"
                                                Target="_blank"
                                                title="@L["Download"]" />
                                 

--- a/src/SynapseAdmin/Controllers/MediaController.cs
+++ b/src/SynapseAdmin/Controllers/MediaController.cs
@@ -25,12 +25,16 @@ public class MediaController(IMediaService mediaService, IMatrixSessionService s
     }
 
     [HttpGet]
-    public async Task<IActionResult> Download(string mxc)
+    public async Task<IActionResult> Download(string mxc, string? filename = null, string? mimeType = null)
     {
         if (string.IsNullOrWhiteSpace(mxc)) return BadRequest();
         
-        logger.LogInformation("Download request for MXC {Mxc} from user {UserId}", 
-            mxc.SanitizeForLogging(), UserId.SanitizeForLogging());
+        // Sanitize parameters
+        var safeFilename = !string.IsNullOrEmpty(filename) ? Path.GetFileName(filename) : null;
+        var safeMimeType = mimeType?.Split(';')[0].Trim(); // Only take the main type, ignore params/injections
+
+        logger.LogInformation("Download request for MXC {Mxc} (file: {Filename}, mime: {MimeType}) from user {UserId}", 
+            mxc.SanitizeForLogging(), safeFilename.SanitizeForLogging(), safeMimeType.SanitizeForLogging(), UserId.SanitizeForLogging());
 
         if (string.IsNullOrEmpty(Homeserver) || string.IsNullOrEmpty(AccessToken))
         {
@@ -48,10 +52,11 @@ public class MediaController(IMediaService mediaService, IMatrixSessionService s
             return NotFound();
         }
 
-        var mxcUri = MxcUri.Parse(mxc);
-        var fileName = mxcUri.MediaId;
+        var mxcUri = LibMatrix.StructuredData.MxcUri.Parse(mxc);
+        var finalFileName = safeFilename ?? mxcUri.MediaId;
+        var finalMimeType = safeMimeType ?? "application/octet-stream";
         
-        return File(result.Data, "application/octet-stream", fileName);
+        return File(result.Data, finalMimeType, finalFileName);
     }
 
     [HttpGet]

--- a/src/SynapseAdmin/Infrastructure/Helpers/MediaHelper.cs
+++ b/src/SynapseAdmin/Infrastructure/Helpers/MediaHelper.cs
@@ -1,0 +1,71 @@
+using System.Collections.Frozen;
+
+namespace SynapseAdmin.Infrastructure.Helpers;
+
+public static class MediaHelper
+{
+    private static readonly FrozenDictionary<string, string> MediaTypeToExtension = new Dictionary<string, string>
+    {
+        // Images
+        { "image/jpeg", ".jpg" },
+        { "image/png", ".png" },
+        { "image/gif", ".gif" },
+        { "image/webp", ".webp" },
+        { "image/svg+xml", ".svg" },
+        { "image/bmp", ".bmp" },
+        { "image/x-icon", ".ico" },
+        { "image/tiff", ".tiff" },
+        
+        // Video
+        { "video/mp4", ".mp4" },
+        { "video/webm", ".webm" },
+        { "video/ogg", ".ogv" },
+        { "video/quicktime", ".mov" },
+        { "video/x-msvideo", ".avi" },
+        
+        // Audio
+        { "audio/mpeg", ".mp3" },
+        { "audio/ogg", ".ogg" },
+        { "audio/wav", ".wav" },
+        { "audio/webm", ".webm" },
+        { "audio/flac", ".flac" },
+        { "audio/aac", ".aac" },
+
+        // Application
+        { "application/pdf", ".pdf" },
+        { "application/zip", ".zip" },
+        { "application/x-tar", ".tar" },
+        { "application/x-rar-compressed", ".rar" },
+        { "application/x-7z-compressed", ".7z" },
+        { "application/json", ".json" },
+        { "application/xml", ".xml" },
+        { "application/msword", ".doc" },
+        { "application/vnd.openxmlformats-officedocument.wordprocessingml.document", ".docx" },
+        { "application/vnd.ms-excel", ".xls" },
+        { "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ".xlsx" },
+        { "application/vnd.ms-powerpoint", ".ppt" },
+        { "application/vnd.openxmlformats-officedocument.presentationml.presentation", ".pptx" },
+        
+        // Text
+        { "text/plain", ".txt" },
+        { "text/html", ".html" },
+        { "text/css", ".css" },
+        { "text/javascript", ".js" },
+        { "text/markdown", ".md" }
+    }.ToFrozenDictionary();
+
+    public static string GetExtensionFromMediaType(string? mediaType)
+    {
+        if (string.IsNullOrEmpty(mediaType)) return ".bin";
+        
+        // Handle types with parameters (e.g. text/html; charset=utf-8)
+        var cleanType = mediaType.Split(';')[0].Trim().ToLowerInvariant();
+        
+        if (MediaTypeToExtension.TryGetValue(cleanType, out var extension))
+        {
+            return extension;
+        }
+
+        return ".bin";
+    }
+}

--- a/src/SynapseAdmin/Models/ViewModels/RoomDetailViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/RoomDetailViewModel.cs
@@ -49,4 +49,23 @@ public class RoomMediaItemViewModel
     public string? MediaType { get; set; }
     public long MediaLength { get; set; }
     public long CreatedTimestamp { get; set; }
+
+    public string DownloadName
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(UploadName)) return UploadName;
+            var mediaIdPart = "media";
+            try
+            {
+                mediaIdPart = LibMatrix.StructuredData.MxcUri.Parse(MediaId).MediaId;
+            }
+            catch
+            {
+                // Fallback to "media" if parsing fails
+            }
+
+            return mediaIdPart + Infrastructure.Helpers.MediaHelper.GetExtensionFromMediaType(MediaType);
+        }
+    }
 }

--- a/src/SynapseAdmin/Models/ViewModels/UserDetailViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/UserDetailViewModel.cs
@@ -43,4 +43,23 @@ public class UserMediaItemViewModel
     public string? MediaType { get; set; }
     public long MediaLength { get; set; }
     public long CreatedTimestamp { get; set; }
+
+    public string DownloadName
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(UploadName)) return UploadName;
+            var mediaIdPart = "media";
+            try
+            {
+                mediaIdPart = LibMatrix.StructuredData.MxcUri.Parse(MediaId).MediaId;
+            }
+            catch
+            {
+                // Fallback to "media" if parsing fails
+            }
+
+            return mediaIdPart + Infrastructure.Helpers.MediaHelper.GetExtensionFromMediaType(MediaType);
+        }
+    }
 }


### PR DESCRIPTION
Implements user-friendly download names for both Room and User media, specifically targeting remote media where the original filename is often missing.

### Changes:
- Added  for MIME type to extension mapping.
- Implemented  property in  and .
- Updated  to accept  and , with sanitization against path traversal and header injection.
- Updated  and  to utilize the improved download parameters.