### PR TITLE
chore: add repomix-output.xml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ TestResult.xml
 nunit-*.xml
 # SynapseAdmin Sensitive Data
 src/SynapseAdmin/keys/
+
+# Tools
+repomix-output.xml


### PR DESCRIPTION
Added the repomix-output.xml file to .gitignore to prevent large repository snapshots from being tracked.