### PR TITLE
feat: add single media quarantine and delete actions to room and user details

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -179,7 +179,7 @@ else
                 }
                 else
                 {
-                    <MudTable T="RoomMediaItemViewModel" ServerData="LoadLocalMedia" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Class="mb-6" RowsPerPage="10">
+                    <MudTable T="RoomMediaItemViewModel" @ref="localMediaTable" ServerData="LoadLocalMedia" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Class="mb-6" RowsPerPage="10">
                         <HeaderContent>
                             <MudTh>@L["MediaId"]</MudTh>
                             <MudTh>@L["FileName"]</MudTh>
@@ -207,6 +207,16 @@ else
                                                        OnClick="@(() => ShowPreview(context))"
                                                        title="@L["Preview"]" />
                                     }
+
+                                    <MudIconButton Icon="@Icons.Material.Filled.Block" 
+                                                   Color="Color.Warning" 
+                                                   OnClick="@(() => QuarantineSingleMedia(context.MediaId))"
+                                                   title="@L["Quarantine"]" />
+                                    
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete" 
+                                                   Color="Color.Error" 
+                                                   OnClick="@(() => DeleteSingleMedia(context.MediaId))"
+                                                   title="@L["Delete"]" />
                                 </div>
                             </MudTd>
                         </RowTemplate>
@@ -223,7 +233,7 @@ else
                 }
                 else
                 {
-                    <MudTable T="RoomMediaItemViewModel" ServerData="LoadRemoteMedia" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" RowsPerPage="10">
+                    <MudTable T="RoomMediaItemViewModel" @ref="remoteMediaTable" ServerData="LoadRemoteMedia" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" RowsPerPage="10">
                         <HeaderContent>
                             <MudTh>@L["MediaId"]</MudTh>
                             <MudTh>@L["FileName"]</MudTh>
@@ -251,6 +261,16 @@ else
                                                        OnClick="@(() => ShowPreview(context))"
                                                        title="@L["Preview"]" />
                                     }
+
+                                    <MudIconButton Icon="@Icons.Material.Filled.Block" 
+                                                   Color="Color.Warning" 
+                                                   OnClick="@(() => QuarantineSingleMedia(context.MediaId))"
+                                                   title="@L["Quarantine"]" />
+                                    
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete" 
+                                                   Color="Color.Error" 
+                                                   OnClick="@(() => DeleteSingleMedia(context.MediaId))"
+                                                   title="@L["Delete"]" />
                                 </div>
                             </MudTd>
                         </RowTemplate>

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
@@ -12,6 +12,8 @@ namespace SynapseAdmin.Components.Pages
         [Inject]
         public IRoomService RoomService { get; set; } = null!;
         [Inject]
+        public IMediaService MediaService { get; set; } = null!;
+        [Inject]
         public NavigationManager Navigation { get; set; } = null!;
         [Inject]
         public ISnackbar Snackbar { get; set; } = null!;
@@ -24,6 +26,8 @@ namespace SynapseAdmin.Components.Pages
         private RoomDetailViewModel? room;
         private RoomMessagesViewModel? messages;
         private bool loadingMessages;
+        private MudTable<RoomMediaItemViewModel>? localMediaTable;
+        private MudTable<RoomMediaItemViewModel>? remoteMediaTable;
 
         protected override async Task OnParametersSetAsync()
         {
@@ -151,6 +155,45 @@ namespace SynapseAdmin.Components.Pages
         {
             var result = await RoomService.BlockRoomAsync(RoomId, true);
             Snackbar.Add(result.Message, result.Severity);
+        }
+
+        private async Task QuarantineSingleMedia(string mxc)
+        {
+            bool? confirmed = await DialogService.ShowMessageBoxAsync(
+                L["QuarantineMediaTitle"],
+                L["QuarantineMediaConfirmation"],
+                yesText: L["Quarantine"], cancelText: L["Cancel"]);
+
+            if (confirmed == true)
+            {
+                var result = await MediaService.QuarantineMediaAsync(mxc);
+                Snackbar.Add(result.Message, result.Severity);
+                if (result.Success)
+                {
+                    await (localMediaTable?.ReloadServerData() ?? Task.CompletedTask);
+                    await (remoteMediaTable?.ReloadServerData() ?? Task.CompletedTask);
+                }
+            }
+        }
+
+        private async Task DeleteSingleMedia(string mxc)
+        {
+            bool? confirmed = await DialogService.ShowMessageBoxAsync(
+                L["DeleteMediaTitle"],
+                L["DeleteMediaConfirmation"],
+                yesText: L["Delete"], cancelText: L["Cancel"]);
+
+            if (confirmed == true)
+            {
+                var result = await MediaService.DeleteMediaAsync(mxc);
+                Snackbar.Add(result.Message, result.Severity);
+                if (result.Success)
+                {
+                    await LoadRoomDetails();
+                    await (localMediaTable?.ReloadServerData() ?? Task.CompletedTask);
+                    await (remoteMediaTable?.ReloadServerData() ?? Task.CompletedTask);
+                }
+            }
         }
 
         private bool IsPreviewable(string? mimeType)

--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor
@@ -126,7 +126,7 @@ else
             }
             else
             {
-                <MudTable Items="user.Media.Media" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0">
+                <MudTable Items="user.Media.Media" @ref="mediaTable" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0">
                     <HeaderContent>
                         <MudTh>@L["MediaId"]</MudTh>
                         <MudTh>@L["FileName"]</MudTh>
@@ -156,6 +156,16 @@ else
                                                    OnClick="@(() => ShowPreview(context))"
                                                    title="@L["Preview"]" />
                                 }
+
+                                <MudIconButton Icon="@Icons.Material.Filled.Block" 
+                                               Color="Color.Warning" 
+                                               OnClick="@(() => QuarantineSingleMedia(context.MediaId))"
+                                               title="@L["Quarantine"]" />
+                                
+                                <MudIconButton Icon="@Icons.Material.Filled.Delete" 
+                                               Color="Color.Error" 
+                                               OnClick="@(() => DeleteSingleMedia(context.MediaId))"
+                                               title="@L["Delete"]" />
                             </div>
                         </MudTd>
                     </RowTemplate>

--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor.cs
@@ -17,11 +17,14 @@ namespace SynapseAdmin.Components.Pages
         public ISnackbar Snackbar { get; set; } = null!;
         [Inject]
         public IDialogService DialogService { get; set; } = null!;
+        [Inject]
+        public IMediaService MediaService { get; set; } = null!;
 
         [Parameter]
         public string UserId { get; set; } = string.Empty;
 
         private UserDetailViewModel? user;
+        private MudTable<UserMediaItemViewModel>? mediaTable;
 
         protected override async Task OnInitializedAsync()
         {
@@ -77,6 +80,44 @@ namespace SynapseAdmin.Components.Pages
         {
             var result = await UserService.LoginAsUserAsync(UserId, TimeSpan.FromHours(1));
             Snackbar.Add(result.Message, result.Severity);
+        }
+
+        private async Task QuarantineSingleMedia(string mediaIdPart)
+        {
+            if (MatrixSession.Gateway == null) return;
+            var mxc = $"mxc://{MatrixSession.Gateway.ServerName}/{mediaIdPart}";
+            
+            bool? confirmed = await DialogService.ShowMessageBoxAsync(
+                L["QuarantineMediaTitle"],
+                L["QuarantineMediaConfirmation"],
+                yesText: L["Quarantine"], cancelText: L["Cancel"]);
+
+            if (confirmed == true)
+            {
+                var result = await MediaService.QuarantineMediaAsync(mxc);
+                Snackbar.Add(result.Message, result.Severity);
+            }
+        }
+
+        private async Task DeleteSingleMedia(string mediaIdPart)
+        {
+            if (MatrixSession.Gateway == null) return;
+            var mxc = $"mxc://{MatrixSession.Gateway.ServerName}/{mediaIdPart}";
+
+            bool? confirmed = await DialogService.ShowMessageBoxAsync(
+                L["DeleteMediaTitle"],
+                L["DeleteMediaConfirmation"],
+                yesText: L["Delete"], cancelText: L["Cancel"]);
+
+            if (confirmed == true)
+            {
+                var result = await MediaService.DeleteMediaAsync(mxc);
+                Snackbar.Add(result.Message, result.Severity);
+                if (result.Success)
+                {
+                    await LoadUserDetails();
+                }
+            }
         }
 
         private bool IsPreviewable(string? mimeType)

--- a/src/SynapseAdmin/Infrastructure/Gateways/MatrixGatewayBase.cs
+++ b/src/SynapseAdmin/Infrastructure/Gateways/MatrixGatewayBase.cs
@@ -104,4 +104,6 @@ public abstract class MatrixGatewayBase(AuthenticatedHomeserverGeneric homeserve
     // Media
     public abstract Task<SynapseAdminMediaMetadataResponse.MediaInfo?> GetMediaMetadataAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
     public abstract Task<SynapseAdminMediaMetadataResponse.MediaInfo?> GetMediaMetadataAsync(MxcUri mxc, CancellationToken cancellationToken = default);
+    public abstract Task QuarantineMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
+    public abstract Task DeleteMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
 }

--- a/src/SynapseAdmin/Infrastructure/Gateways/SynapseAdminGateway.cs
+++ b/src/SynapseAdmin/Infrastructure/Gateways/SynapseAdminGateway.cs
@@ -221,7 +221,7 @@ public class SynapseAdminGateway(AuthenticatedHomeserverSynapse synapse) : Matri
         return await _synapse.ClientHttpClient.GetFromJsonAsync<SynapseVersionResponse>("/_synapse/admin/v1/server_version", cancellationToken: cancellationToken);
     }
 
-    // --- Media ---
+    // Media
 
     public override async Task<SynapseAdminMediaMetadataResponse.MediaInfo?> GetMediaMetadataAsync(string serverName, string mediaId, CancellationToken cancellationToken = default)
     {
@@ -234,4 +234,15 @@ public class SynapseAdminGateway(AuthenticatedHomeserverSynapse synapse) : Matri
     {
         return await GetMediaMetadataAsync(mxc.ServerName, mxc.MediaId, cancellationToken);
     }
-}
+
+    public override async Task QuarantineMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default)
+    {
+        await _synapse.Admin.QuarantineMediaById(serverName, mediaId);
+    }
+
+    public override async Task DeleteMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default)
+    {
+        await _synapse.Admin.DeleteMediaById(serverName, mediaId);
+    }
+    }
+

--- a/src/SynapseAdmin/Interfaces/Gateways/IMatrixGateway.cs
+++ b/src/SynapseAdmin/Interfaces/Gateways/IMatrixGateway.cs
@@ -67,4 +67,6 @@ public interface IMatrixGateway
     Task<Stream> GetMediaStreamAsync(string mxcUri, string? filename = null, int? timeout = null, CancellationToken cancellationToken = default);
     Task<SynapseAdminMediaMetadataResponse.MediaInfo?> GetMediaMetadataAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
     Task<SynapseAdminMediaMetadataResponse.MediaInfo?> GetMediaMetadataAsync(MxcUri mxc, CancellationToken cancellationToken = default);
+    Task QuarantineMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
+    Task DeleteMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
 }

--- a/src/SynapseAdmin/Interfaces/IMediaService.cs
+++ b/src/SynapseAdmin/Interfaces/IMediaService.cs
@@ -7,4 +7,6 @@ public interface IMediaService
 {
     Task<OperationResult<Stream>> GetMediaStreamAsync(string mxc);
     Task<OperationResult<SynapseAdminMediaMetadataResponse.MediaInfo>> GetMediaMetadataAsync(string mxc);
+    Task<OperationResult> QuarantineMediaAsync(string mxc, CancellationToken token = default);
+    Task<OperationResult> DeleteMediaAsync(string mxc, CancellationToken token = default);
 }

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -775,4 +775,19 @@
   <data name="ErrorSessionBridgeFailed" xml:space="preserve">
     <value>Die Anmeldesitzung ist abgelaufen oder ungültig. Bitte versuchen Sie, sich erneut anzumelden.</value>
   </data>
+  <data name="MediaQuarantinedSuccessfully" xml:space="preserve">
+    <value>Medien erfolgreich unter Quarantäne gestellt.</value>
+  </data>
+  <data name="MediaDeletedSuccessfully" xml:space="preserve">
+    <value>Medien erfolgreich gelöscht.</value>
+  </data>
+  <data name="QuarantineMediaConfirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie diese Medien unter Quarantäne stellen möchten?</value>
+  </data>
+  <data name="DeleteMediaConfirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie diese Medien löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.</value>
+  </data>
+  <data name="DeleteMediaTitle" xml:space="preserve">
+    <value>Medien löschen</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -775,4 +775,19 @@
   <data name="ErrorSessionBridgeFailed" xml:space="preserve">
     <value>La session de connexion a expiré ou est invalide. Veuillez essayer de vous reconnecter.</value>
   </data>
+  <data name="MediaQuarantinedSuccessfully" xml:space="preserve">
+    <value>Média mis en quarantaine avec succès.</value>
+  </data>
+  <data name="MediaDeletedSuccessfully" xml:space="preserve">
+    <value>Média supprimé avec succès.</value>
+  </data>
+  <data name="QuarantineMediaConfirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir mettre ce média en quarantaine ?</value>
+  </data>
+  <data name="DeleteMediaConfirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir supprimer ce média ? Cette action est irréversible.</value>
+  </data>
+  <data name="DeleteMediaTitle" xml:space="preserve">
+    <value>Supprimer le média</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -776,4 +776,19 @@
   <data name="ErrorSessionBridgeFailed" xml:space="preserve">
     <value>The login session expired or is invalid. Please try logging in again.</value>
   </data>
+  <data name="MediaQuarantinedSuccessfully" xml:space="preserve">
+    <value>Media quarantined successfully.</value>
+  </data>
+  <data name="MediaDeletedSuccessfully" xml:space="preserve">
+    <value>Media deleted successfully.</value>
+  </data>
+  <data name="QuarantineMediaConfirmation" xml:space="preserve">
+    <value>Are you sure you want to quarantine this media?</value>
+  </data>
+  <data name="DeleteMediaConfirmation" xml:space="preserve">
+    <value>Are you sure you want to delete this media? This action cannot be undone.</value>
+  </data>
+  <data name="DeleteMediaTitle" xml:space="preserve">
+    <value>Delete Media</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Services/MediaService.cs
+++ b/src/SynapseAdmin/Services/MediaService.cs
@@ -5,6 +5,7 @@ using SynapseAdmin.Models;
 using SynapseAdmin.Models.Responses;
 using SynapseAdmin.Resources;
 using SynapseAdmin.Interfaces.Gateways;
+using LibMatrix.StructuredData;
 
 namespace SynapseAdmin.Services;
 
@@ -36,7 +37,7 @@ public class MediaService(IMatrixSessionService sessionService, ILogger<MediaSer
 
         try
         {
-            var mxcUri = LibMatrix.StructuredData.MxcUri.Parse(mxc);
+            var mxcUri = MxcUri.Parse(mxc);
             var meta = await Gateway.GetMediaMetadataAsync(mxcUri);
             if (meta == null) return OperationResult<SynapseAdminMediaMetadataResponse.MediaInfo>.Failure(L["ErrorFetchingMedia"]);
             return OperationResult<SynapseAdminMediaMetadataResponse.MediaInfo>.Ok(meta);
@@ -45,6 +46,40 @@ public class MediaService(IMatrixSessionService sessionService, ILogger<MediaSer
         {
             logger.LogError(ex, "Error fetching media metadata for MXC: {Mxc}", mxc.SanitizeForLogging());
             return OperationResult<SynapseAdminMediaMetadataResponse.MediaInfo>.Failure(L["ErrorFetchingMedia"]);
+        }
+    }
+
+    public async Task<OperationResult> QuarantineMediaAsync(string mxc, CancellationToken token = default)
+    {
+        if (Gateway == null) return OperationResult.Failure(L["NotAuthenticated"]);
+        try
+        {
+            var parsed = MxcUri.Parse(mxc);
+            await Gateway.QuarantineMediaAsync(parsed.ServerName, parsed.MediaId, token);
+            logger.LogInformation("Successfully quarantined media {Mxc}", mxc.SanitizeForLogging());
+            return OperationResult.Ok(L["MediaQuarantinedSuccessfully"]);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error quarantining media {Mxc}", mxc.SanitizeForLogging());
+            return OperationResult.Failure(L["ErrorQuarantiningMedia"]);
+        }
+    }
+
+    public async Task<OperationResult> DeleteMediaAsync(string mxc, CancellationToken token = default)
+    {
+        if (Gateway == null) return OperationResult.Failure(L["NotAuthenticated"]);
+        try
+        {
+            var parsed = MxcUri.Parse(mxc);
+            await Gateway.DeleteMediaAsync(parsed.ServerName, parsed.MediaId, token);
+            logger.LogInformation("Successfully deleted media {Mxc}", mxc.SanitizeForLogging());
+            return OperationResult.Ok(L["MediaDeletedSuccessfully"]);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error deleting media {Mxc}", mxc.SanitizeForLogging());
+            return OperationResult.Failure(L["ErrorDeletingMedia"]);
         }
     }
 }


### PR DESCRIPTION
This PR adds the ability to quarantine or delete single media items from both the Room Details and User Details pages. The core logic has been consolidated into the `MediaService` for reuse and maintainability.