### PR TITLE
fix: handle number type for next_token in user media API

### DIFF
--- a/src/SynapseAdmin/Infrastructure/Gateways/SynapseAdminGateway.cs
+++ b/src/SynapseAdmin/Infrastructure/Gateways/SynapseAdminGateway.cs
@@ -9,7 +9,9 @@ using SynapseAdmin.Models.Responses;
 using SynapseAdmin.Models.Requests;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text.Json;
 using ArcaneLibs.Extensions;
+using SynapseAdmin.Infrastructure.Serialization;
 
 namespace SynapseAdmin.Infrastructure.Gateways;
 
@@ -21,6 +23,14 @@ namespace SynapseAdmin.Infrastructure.Gateways;
 public class SynapseAdminGateway(AuthenticatedHomeserverSynapse synapse) : MatrixGatewayBase(synapse)
 {
     private readonly AuthenticatedHomeserverSynapse _synapse = synapse;
+
+    /// <summary>
+    /// Custom options to handle Synapse's inconsistent next_token types (String vs Number).
+    /// </summary>
+    private static readonly JsonSerializerOptions SynapseCompatibilityJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringConverter() }
+    };
 
     // --- User Management ---
 
@@ -85,9 +95,10 @@ public class SynapseAdminGateway(AuthenticatedHomeserverSynapse synapse) : Matri
 
     public override async Task<SynapseAdminUserMediaResult?> GetUserMediaAsync(string userId, CancellationToken cancellationToken = default)
     {
-        // SDK doesn't support CancellationToken here
-        return await _synapse.Admin.GetUserMediaAsync(userId);
+        var url = $"/_synapse/admin/v1/users/{userId.UrlEncode()}/media";
+        return await _synapse.ClientHttpClient.GetFromJsonAsync<SynapseAdminUserMediaResult>(url, SynapseCompatibilityJsonOptions, cancellationToken: cancellationToken);
     }
+
 
     // --- Room Management ---
 

--- a/src/SynapseAdmin/Infrastructure/Serialization/JsonStringConverter.cs
+++ b/src/SynapseAdmin/Infrastructure/Serialization/JsonStringConverter.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SynapseAdmin.Infrastructure.Serialization;
+
+/// <summary>
+/// A custom converter that allows reading JSON Numbers (and other types) as Strings.
+/// This is used as a workaround for Synapse Admin API inconsistencies where 
+/// next_token can be either a string or a number.
+/// </summary>
+public class JsonStringConverter : JsonConverter<string>
+{
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.String => reader.GetString(),
+            JsonTokenType.Number => reader.TryGetInt64(out long l) ? l.ToString() : reader.GetDouble().ToString(),
+            JsonTokenType.True => "true",
+            JsonTokenType.False => "false",
+            JsonTokenType.Null => null,
+            _ => throw new JsonException($"Unexpected token {reader.TokenType} when parsing string.")
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value);
+    }
+}


### PR DESCRIPTION
Resolves #192. 

Summary of changes:
- Created `JsonStringConverter` to handle JSON Number-to-String coercion during deserialization.
- Implemented `SynapseCompatibilityJsonOptions` in `SynapseAdminGateway` to apply this converter.
- Reimplemented `GetUserMediaAsync` to use the compatibility options, bypassing the SDK's strict type expectation.
- Verified fix allows viewing user details for accounts with large media counts.