### PR TITLE
feat: add logout warning for shared PCs on login page

### DIFF
--- a/src/SynapseAdmin/Components/Pages/Login.razor
+++ b/src/SynapseAdmin/Components/Pages/Login.razor
@@ -61,5 +61,9 @@
                 }
             </MudButton>
         </EditForm>
+
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-8" Icon="@Icons.Material.Filled.Security">
+            @L["SharedPcWarning"]
+        </MudAlert>
     </MudPaper>
 </MudContainer>

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -790,4 +790,7 @@
   <data name="DeleteMediaTitle" xml:space="preserve">
     <value>Medien löschen</value>
   </data>
+  <data name="SharedPcWarning" xml:space="preserve">
+    <value>Sicherheitshinweis: Wenn Sie einen öffentlichen oder gemeinsam genutzten Computer verwenden, denken Sie bitte daran, sich nach Abschluss Ihrer Arbeit abzumelden.</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -790,4 +790,7 @@
   <data name="DeleteMediaTitle" xml:space="preserve">
     <value>Supprimer le média</value>
   </data>
+  <data name="SharedPcWarning" xml:space="preserve">
+    <value>Note de sécurité : Si vous utilisez un ordinateur public ou partagé, n'oubliez pas de vous déconnecter lorsque vous avez terminé.</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -791,4 +791,7 @@
   <data name="DeleteMediaTitle" xml:space="preserve">
     <value>Delete Media</value>
   </data>
+  <data name="SharedPcWarning" xml:space="preserve">
+    <value>Security Note: If you are using a public or shared computer, please remember to log out when you are finished.</value>
+  </data>
 </root>


### PR DESCRIPTION
Resolves #196. Adds a localized security notice to the login page to encourage session cleanup.