### PR TITLE
feat: indicate quarantine status in media views

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -188,30 +188,43 @@ else
                             <MudTh>@L["Actions"]</MudTh>
                         </HeaderContent>
                         <RowTemplate>
-                            <MudTd DataLabel="@L["MediaId"]">@context.MediaId</MudTd>
+                            <MudTd DataLabel="@L["MediaId"]">
+                                <div class="d-flex flex-column">
+                                    @context.MediaId
+                                    @if (context.IsQuarantined)
+                                    {
+                                        <MudTooltip Text="@($"{L["QuarantinedBy"]}: {context.QuarantinedBy}")">
+                                            <MudChip T="string" Color="Color.Error" Size="Size.Small" Variant="Variant.Text" Class="mt-1">@L["Quarantined"]</MudChip>
+                                        </MudTooltip>
+                                    }
+                                </div>
+                            </MudTd>
                             <MudTd DataLabel="@L["FileName"]">@context.UploadName</MudTd>
                             <MudTd DataLabel="@L["Type"]">@context.MediaType</MudTd>
                             <MudTd DataLabel="@L["Size"]">@(context.MediaLength > 0 ? $"{(context.MediaLength / 1024)} KB" : "")</MudTd>
                             <MudTd DataLabel="@L["Actions"]">
                                 <div class="d-flex">
-                                    <MudIconButton Icon="@Icons.Material.Filled.Download" 
-                                                   Color="Color.Primary" 
-                                                   Href="@($"/Media/Download?mxc={Uri.EscapeDataString(context.MediaId)}&filename={Uri.EscapeDataString(context.DownloadName)}&mimeType={Uri.EscapeDataString(context.MediaType ?? "application/octet-stream")}")"
-                                                   Target="_blank"
-                                                   title="@L["Download"]" />
-                                    
-                                    @if (IsPreviewable(context.MediaType))
+                                    @if (!context.IsQuarantined)
                                     {
-                                        <MudIconButton Icon="@Icons.Material.Filled.Visibility" 
-                                                       Color="Color.Secondary" 
-                                                       OnClick="@(() => ShowPreview(context))"
-                                                       title="@L["Preview"]" />
-                                    }
+                                        <MudIconButton Icon="@Icons.Material.Filled.Download" 
+                                                       Color="Color.Primary" 
+                                                       Href="@($"/Media/Download?mxc={Uri.EscapeDataString(context.MediaId)}&filename={Uri.EscapeDataString(context.DownloadName)}&mimeType={Uri.EscapeDataString(context.MediaType ?? "application/octet-stream")}")"
+                                                       Target="_blank"
+                                                       title="@L["Download"]" />
+                                        
+                                        @if (IsPreviewable(context.MediaType))
+                                        {
+                                            <MudIconButton Icon="@Icons.Material.Filled.Visibility" 
+                                                           Color="Color.Secondary" 
+                                                           OnClick="@(() => ShowPreview(context))"
+                                                           title="@L["Preview"]" />
+                                        }
 
-                                    <MudIconButton Icon="@Icons.Material.Filled.Block" 
-                                                   Color="Color.Warning" 
-                                                   OnClick="@(() => QuarantineSingleMedia(context.MediaId))"
-                                                   title="@L["Quarantine"]" />
+                                        <MudIconButton Icon="@Icons.Material.Filled.Block" 
+                                                       Color="Color.Warning" 
+                                                       OnClick="@(() => QuarantineSingleMedia(context.MediaId))"
+                                                       title="@L["Quarantine"]" />
+                                    }
                                     
                                     <MudIconButton Icon="@Icons.Material.Filled.Delete" 
                                                    Color="Color.Error" 
@@ -242,30 +255,43 @@ else
                             <MudTh>@L["Actions"]</MudTh>
                         </HeaderContent>
                         <RowTemplate>
-                            <MudTd DataLabel="@L["MediaId"]">@context.MediaId</MudTd>
+                            <MudTd DataLabel="@L["MediaId"]">
+                                <div class="d-flex flex-column">
+                                    @context.MediaId
+                                    @if (context.IsQuarantined)
+                                    {
+                                        <MudTooltip Text="@($"{L["QuarantinedBy"]}: {context.QuarantinedBy}")">
+                                            <MudChip T="string" Color="Color.Error" Size="Size.Small" Variant="Variant.Text" Class="mt-1">@L["Quarantined"]</MudChip>
+                                        </MudTooltip>
+                                    }
+                                </div>
+                            </MudTd>
                             <MudTd DataLabel="@L["FileName"]">@context.UploadName</MudTd>
                             <MudTd DataLabel="@L["Type"]">@context.MediaType</MudTd>
                             <MudTd DataLabel="@L["Size"]">@(context.MediaLength > 0 ? $"{(context.MediaLength / 1024)} KB" : "")</MudTd>
                             <MudTd DataLabel="@L["Actions"]">
                                 <div class="d-flex">
-                                    <MudIconButton Icon="@Icons.Material.Filled.Download" 
-                                                   Color="Color.Primary" 
-                                                   Href="@($"/Media/Download?mxc={Uri.EscapeDataString(context.MediaId)}&filename={Uri.EscapeDataString(context.DownloadName)}&mimeType={Uri.EscapeDataString(context.MediaType ?? "application/octet-stream")}")"
-                                                   Target="_blank"
-                                                   title="@L["Download"]" />
-                                    
-                                    @if (IsPreviewable(context.MediaType))
+                                    @if (!context.IsQuarantined)
                                     {
-                                        <MudIconButton Icon="@Icons.Material.Filled.Visibility" 
-                                                       Color="Color.Secondary" 
-                                                       OnClick="@(() => ShowPreview(context))"
-                                                       title="@L["Preview"]" />
-                                    }
+                                        <MudIconButton Icon="@Icons.Material.Filled.Download" 
+                                                       Color="Color.Primary" 
+                                                       Href="@($"/Media/Download?mxc={Uri.EscapeDataString(context.MediaId)}&filename={Uri.EscapeDataString(context.DownloadName)}&mimeType={Uri.EscapeDataString(context.MediaType ?? "application/octet-stream")}")"
+                                                       Target="_blank"
+                                                       title="@L["Download"]" />
+                                        
+                                        @if (IsPreviewable(context.MediaType))
+                                        {
+                                            <MudIconButton Icon="@Icons.Material.Filled.Visibility" 
+                                                           Color="Color.Secondary" 
+                                                           OnClick="@(() => ShowPreview(context))"
+                                                           title="@L["Preview"]" />
+                                        }
 
-                                    <MudIconButton Icon="@Icons.Material.Filled.Block" 
-                                                   Color="Color.Warning" 
-                                                   OnClick="@(() => QuarantineSingleMedia(context.MediaId))"
-                                                   title="@L["Quarantine"]" />
+                                        <MudIconButton Icon="@Icons.Material.Filled.Block" 
+                                                       Color="Color.Warning" 
+                                                       OnClick="@(() => QuarantineSingleMedia(context.MediaId))"
+                                                       title="@L["Quarantine"]" />
+                                    }
                                     
                                     <MudIconButton Icon="@Icons.Material.Filled.Delete" 
                                                    Color="Color.Error" 

--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor
@@ -136,31 +136,44 @@ else
                         <MudTh>@L["Actions"]</MudTh>
                     </HeaderContent>
                     <RowTemplate>
-                        <MudTd DataLabel="@L["MediaId"]">@context.MediaId</MudTd>
+                        <MudTd DataLabel="@L["MediaId"]">
+                            <div class="d-flex flex-column">
+                                @context.MediaId
+                                @if (context.IsQuarantined)
+                                {
+                                    <MudTooltip Text="@($"{L["QuarantinedBy"]}: {context.QuarantinedBy}")">
+                                        <MudChip T="string" Color="Color.Error" Size="Size.Small" Variant="Variant.Text" Class="mt-1">@L["Quarantined"]</MudChip>
+                                    </MudTooltip>
+                                }
+                            </div>
+                        </MudTd>
                         <MudTd DataLabel="@L["FileName"]">@context.UploadName</MudTd>
                         <MudTd DataLabel="@L["Type"]">@context.MediaType</MudTd>
                         <MudTd DataLabel="@L["Size"]">@(context.MediaLength / 1024) KB</MudTd>
                         <MudTd DataLabel="@L["Created"]">@DateTimeOffset.FromUnixTimeMilliseconds(context.CreatedTimestamp).DateTime.ToString("g")</MudTd>
                         <MudTd DataLabel="@L["Actions"]">
                             <div class="d-flex">
-                                <MudIconButton Icon="@Icons.Material.Filled.Download" 
-                                               Color="Color.Primary" 
-                                               Href="@($"/Media/Download?mxc={Uri.EscapeDataString($"mxc://{MatrixSession.Gateway!.ServerName}/{context.MediaId}")}&filename={Uri.EscapeDataString(context.DownloadName)}&mimeType={Uri.EscapeDataString(context.MediaType ?? "application/octet-stream")}")"
-                                               Target="_blank"
-                                               title="@L["Download"]" />
-                                
-                                @if (IsPreviewable(context.MediaType))
+                                @if (!context.IsQuarantined)
                                 {
-                                    <MudIconButton Icon="@Icons.Material.Filled.Visibility" 
-                                                   Color="Color.Secondary" 
-                                                   OnClick="@(() => ShowPreview(context))"
-                                                   title="@L["Preview"]" />
-                                }
+                                    <MudIconButton Icon="@Icons.Material.Filled.Download" 
+                                                   Color="Color.Primary" 
+                                                   Href="@($"/Media/Download?mxc={Uri.EscapeDataString($"mxc://{MatrixSession.Gateway!.ServerName}/{context.MediaId}")}&filename={Uri.EscapeDataString(context.DownloadName)}&mimeType={Uri.EscapeDataString(context.MediaType ?? "application/octet-stream")}")"
+                                                   Target="_blank"
+                                                   title="@L["Download"]" />
+                                    
+                                    @if (IsPreviewable(context.MediaType))
+                                    {
+                                        <MudIconButton Icon="@Icons.Material.Filled.Visibility" 
+                                                       Color="Color.Secondary" 
+                                                       OnClick="@(() => ShowPreview(context))"
+                                                       title="@L["Preview"]" />
+                                    }
 
-                                <MudIconButton Icon="@Icons.Material.Filled.Block" 
-                                               Color="Color.Warning" 
-                                               OnClick="@(() => QuarantineSingleMedia(context.MediaId))"
-                                               title="@L["Quarantine"]" />
+                                    <MudIconButton Icon="@Icons.Material.Filled.Block" 
+                                                   Color="Color.Warning" 
+                                                   OnClick="@(() => QuarantineSingleMedia(context.MediaId))"
+                                                   title="@L["Quarantine"]" />
+                                }
                                 
                                 <MudIconButton Icon="@Icons.Material.Filled.Delete" 
                                                Color="Color.Error" 

--- a/src/SynapseAdmin/Models/ViewModels/RoomDetailViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/RoomDetailViewModel.cs
@@ -49,6 +49,8 @@ public class RoomMediaItemViewModel
     public string? MediaType { get; set; }
     public long MediaLength { get; set; }
     public long CreatedTimestamp { get; set; }
+    public string? QuarantinedBy { get; set; }
+    public bool IsQuarantined => !string.IsNullOrEmpty(QuarantinedBy);
 
     public string DownloadName
     {

--- a/src/SynapseAdmin/Models/ViewModels/UserDetailViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/UserDetailViewModel.cs
@@ -42,6 +42,8 @@ public class UserMediaItemViewModel
     public string? MediaType { get; set; }
     public long MediaLength { get; set; }
     public long CreatedTimestamp { get; set; }
+    public string? QuarantinedBy { get; set; }
+    public bool IsQuarantined => !string.IsNullOrEmpty(QuarantinedBy);
 
     public string DownloadName
     {

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -793,4 +793,10 @@
   <data name="SharedPcWarning" xml:space="preserve">
     <value>Sicherheitshinweis: Wenn Sie einen öffentlichen oder gemeinsam genutzten Computer verwenden, denken Sie bitte daran, sich nach Abschluss Ihrer Arbeit abzumelden.</value>
   </data>
+  <data name="Quarantined" xml:space="preserve">
+    <value>In Quarantäne</value>
+  </data>
+  <data name="QuarantinedBy" xml:space="preserve">
+    <value>Quarantäne durch</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -793,4 +793,10 @@
   <data name="SharedPcWarning" xml:space="preserve">
     <value>Note de sécurité : Si vous utilisez un ordinateur public ou partagé, n'oubliez pas de vous déconnecter lorsque vous avez terminé.</value>
   </data>
-</root>
+  <data name="Quarantined" xml:space="preserve">
+    <value>En quarantaine</value>
+  </data>
+  <data name="QuarantinedBy" xml:space="preserve">
+    <value>Mis en quarantaine par</value>
+  </data>
+  </root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -794,4 +794,10 @@
   <data name="SharedPcWarning" xml:space="preserve">
     <value>Security Note: If you are using a public or shared computer, please remember to log out when you are finished.</value>
   </data>
+  <data name="Quarantined" xml:space="preserve">
+    <value>Quarantined</value>
+  </data>
+  <data name="QuarantinedBy" xml:space="preserve">
+    <value>Quarantined by</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Services/RoomService.cs
+++ b/src/SynapseAdmin/Services/RoomService.cs
@@ -109,6 +109,7 @@ public class RoomService(IMatrixSessionService sessionService, ILogger<RoomServi
                         vm.MediaType = meta.MediaType;
                         vm.MediaLength = meta.MediaLength;
                         vm.CreatedTimestamp = meta.CreatedTimestamp;
+                        vm.QuarantinedBy = meta.QuarantinedBy;
                     }
                 }
                 catch (Exception ex)

--- a/src/SynapseAdmin/Services/UserService.cs
+++ b/src/SynapseAdmin/Services/UserService.cs
@@ -67,7 +67,8 @@ public class UserService(IMatrixSessionService sessionService, ILogger<UserServi
                     UploadName = m.UploadName,
                     MediaType = m.MediaType,
                     MediaLength = m.MediaLength,
-                    CreatedTimestamp = m.CreatedTimestamp
+                    CreatedTimestamp = m.CreatedTimestamp,
+                    QuarantinedBy = m.QuarantinedBy
                 }).ToList()
             };
             vm.Memberships = membershipsResult.Success ? (membershipsResult.Data ?? []) : [];


### PR DESCRIPTION
Resolves #198. Updates the media tables in User and Room details to explicitly show when an item is quarantined and prevent impossible actions (preview/download) on those items.