### PR TITLE
feat: add unquarantine action for media

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -225,6 +225,13 @@ else
                                                        OnClick="@(() => QuarantineSingleMedia(context.MediaId))"
                                                        title="@L["Quarantine"]" />
                                     }
+                                    else
+                                    {
+                                        <MudIconButton Icon="@Icons.Material.Filled.LockOpen" 
+                                                       Color="Color.Success" 
+                                                       OnClick="@(() => UnquarantineSingleMedia(context.MediaId))"
+                                                       title="@L["Unquarantine"]" />
+                                    }
                                     
                                     <MudIconButton Icon="@Icons.Material.Filled.Delete" 
                                                    Color="Color.Error" 
@@ -291,6 +298,13 @@ else
                                                        Color="Color.Warning" 
                                                        OnClick="@(() => QuarantineSingleMedia(context.MediaId))"
                                                        title="@L["Quarantine"]" />
+                                    }
+                                    else
+                                    {
+                                        <MudIconButton Icon="@Icons.Material.Filled.LockOpen" 
+                                                       Color="Color.Success" 
+                                                       OnClick="@(() => UnquarantineSingleMedia(context.MediaId))"
+                                                       title="@L["Unquarantine"]" />
                                     }
                                     
                                     <MudIconButton Icon="@Icons.Material.Filled.Delete" 

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
@@ -176,6 +176,25 @@ namespace SynapseAdmin.Components.Pages
             }
         }
 
+        private async Task UnquarantineSingleMedia(string mxc)
+        {
+            bool? confirmed = await DialogService.ShowMessageBoxAsync(
+                L["UnquarantineMediaTitle"],
+                L["UnquarantineMediaConfirmation"],
+                yesText: L["Unquarantine"], cancelText: L["Cancel"]);
+
+            if (confirmed == true)
+            {
+                var result = await MediaService.UnquarantineMediaAsync(mxc);
+                Snackbar.Add(result.Message, result.Severity);
+                if (result.Success)
+                {
+                    await (localMediaTable?.ReloadServerData() ?? Task.CompletedTask);
+                    await (remoteMediaTable?.ReloadServerData() ?? Task.CompletedTask);
+                }
+            }
+        }
+
         private async Task DeleteSingleMedia(string mxc)
         {
             bool? confirmed = await DialogService.ShowMessageBoxAsync(

--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor
@@ -136,52 +136,60 @@ else
                         <MudTh>@L["Actions"]</MudTh>
                     </HeaderContent>
                     <RowTemplate>
-                        <MudTd DataLabel="@L["MediaId"]">
-                            <div class="d-flex flex-column">
-                                @context.MediaId
-                                @if (context.IsQuarantined)
-                                {
-                                    <MudTooltip Text="@($"{L["QuarantinedBy"]}: {context.QuarantinedBy}")">
-                                        <MudChip T="string" Color="Color.Error" Size="Size.Small" Variant="Variant.Text" Class="mt-1">@L["Quarantined"]</MudChip>
-                                    </MudTooltip>
-                                }
-                            </div>
-                        </MudTd>
-                        <MudTd DataLabel="@L["FileName"]">@context.UploadName</MudTd>
-                        <MudTd DataLabel="@L["Type"]">@context.MediaType</MudTd>
-                        <MudTd DataLabel="@L["Size"]">@(context.MediaLength / 1024) KB</MudTd>
-                        <MudTd DataLabel="@L["Created"]">@DateTimeOffset.FromUnixTimeMilliseconds(context.CreatedTimestamp).DateTime.ToString("g")</MudTd>
-                        <MudTd DataLabel="@L["Actions"]">
-                            <div class="d-flex">
-                                @if (!context.IsQuarantined)
-                                {
-                                    <MudIconButton Icon="@Icons.Material.Filled.Download" 
-                                                   Color="Color.Primary" 
-                                                   Href="@($"/Media/Download?mxc={Uri.EscapeDataString($"mxc://{MatrixSession.Gateway!.ServerName}/{context.MediaId}")}&filename={Uri.EscapeDataString(context.DownloadName)}&mimeType={Uri.EscapeDataString(context.MediaType ?? "application/octet-stream")}")"
-                                                   Target="_blank"
-                                                   title="@L["Download"]" />
-                                    
-                                    @if (IsPreviewable(context.MediaType))
-                                    {
-                                        <MudIconButton Icon="@Icons.Material.Filled.Visibility" 
-                                                       Color="Color.Secondary" 
-                                                       OnClick="@(() => ShowPreview(context))"
-                                                       title="@L["Preview"]" />
-                                    }
+                    <MudTd DataLabel="@L["MediaId"]">
+                    <div class="d-flex flex-column">
+                    @context.MediaId
+                    @if (context.IsQuarantined)
+                    {
+                        <MudTooltip Text="@($"{L["QuarantinedBy"]}: {context.QuarantinedBy}")">
+                            <MudChip T="string" Color="Color.Error" Size="Size.Small" Variant="Variant.Text" Class="mt-1">@L["Quarantined"]</MudChip>
+                        </MudTooltip>
+                    }
+                    </div>
+                    </MudTd>
+                    <MudTd DataLabel="@L["FileName"]">@context.UploadName</MudTd>
+                    <MudTd DataLabel="@L["Type"]">@context.MediaType</MudTd>
+                    <MudTd DataLabel="@L["Size"]">@(context.MediaLength / 1024) KB</MudTd>
+                    <MudTd DataLabel="@L["Created"]">@DateTimeOffset.FromUnixTimeMilliseconds(context.CreatedTimestamp).DateTime.ToString("g")</MudTd>
+                    <MudTd DataLabel="@L["Actions"]">
+                    <div class="d-flex">
+                    @if (!context.IsQuarantined)
+                    {
+                        <MudIconButton Icon="@Icons.Material.Filled.Download" 
+                                       Color="Color.Primary" 
+                                       Href="@($"/Media/Download?mxc={Uri.EscapeDataString($"mxc://{MatrixSession.Gateway!.ServerName}/{context.MediaId}")}&filename={Uri.EscapeDataString(context.DownloadName)}&mimeType={Uri.EscapeDataString(context.MediaType ?? "application/octet-stream")}")"
+                                       Target="_blank"
+                                       title="@L["Download"]" />
 
-                                    <MudIconButton Icon="@Icons.Material.Filled.Block" 
-                                                   Color="Color.Warning" 
-                                                   OnClick="@(() => QuarantineSingleMedia(context.MediaId))"
-                                                   title="@L["Quarantine"]" />
-                                }
-                                
-                                <MudIconButton Icon="@Icons.Material.Filled.Delete" 
-                                               Color="Color.Error" 
-                                               OnClick="@(() => DeleteSingleMedia(context.MediaId))"
-                                               title="@L["Delete"]" />
-                            </div>
-                        </MudTd>
+                        @if (IsPreviewable(context.MediaType))
+                        {
+                            <MudIconButton Icon="@Icons.Material.Filled.Visibility" 
+                                           Color="Color.Secondary" 
+                                           OnClick="@(() => ShowPreview(context))"
+                                           title="@L["Preview"]" />
+                        }
+
+                        <MudIconButton Icon="@Icons.Material.Filled.Block" 
+                                       Color="Color.Warning" 
+                                       OnClick="@(() => QuarantineSingleMedia(context.MediaId))"
+                                       title="@L["Quarantine"]" />
+                    }
+                    else
+                    {
+                        <MudIconButton Icon="@Icons.Material.Filled.LockOpen" 
+                                       Color="Color.Success" 
+                                       OnClick="@(() => UnquarantineSingleMedia(context.MediaId))"
+                                       title="@L["Unquarantine"]" />
+                    }
+
+                    <MudIconButton Icon="@Icons.Material.Filled.Delete" 
+                                   Color="Color.Error" 
+                                   OnClick="@(() => DeleteSingleMedia(context.MediaId))"
+                                   title="@L["Delete"]" />
+                    </div>
+                    </MudTd>
                     </RowTemplate>
+
                     <PagerContent>
                         <MudTablePager />
                     </PagerContent>

--- a/src/SynapseAdmin/Components/Pages/UserDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/UserDetails.razor.cs
@@ -96,6 +96,31 @@ namespace SynapseAdmin.Components.Pages
             {
                 var result = await MediaService.QuarantineMediaAsync(mxc);
                 Snackbar.Add(result.Message, result.Severity);
+                if (result.Success)
+                {
+                    await LoadUserDetails();
+                }
+            }
+        }
+
+        private async Task UnquarantineSingleMedia(string mediaIdPart)
+        {
+            if (MatrixSession.Gateway == null) return;
+            var mxc = $"mxc://{MatrixSession.Gateway.ServerName}/{mediaIdPart}";
+
+            bool? confirmed = await DialogService.ShowMessageBoxAsync(
+                L["UnquarantineMediaTitle"],
+                L["UnquarantineMediaConfirmation"],
+                yesText: L["Unquarantine"], cancelText: L["Cancel"]);
+
+            if (confirmed == true)
+            {
+                var result = await MediaService.UnquarantineMediaAsync(mxc);
+                Snackbar.Add(result.Message, result.Severity);
+                if (result.Success)
+                {
+                    await LoadUserDetails();
+                }
             }
         }
 

--- a/src/SynapseAdmin/Infrastructure/Gateways/MatrixGatewayBase.cs
+++ b/src/SynapseAdmin/Infrastructure/Gateways/MatrixGatewayBase.cs
@@ -105,5 +105,6 @@ public abstract class MatrixGatewayBase(AuthenticatedHomeserverGeneric homeserve
     public abstract Task<SynapseAdminMediaMetadataResponse.MediaInfo?> GetMediaMetadataAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
     public abstract Task<SynapseAdminMediaMetadataResponse.MediaInfo?> GetMediaMetadataAsync(MxcUri mxc, CancellationToken cancellationToken = default);
     public abstract Task QuarantineMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
+    public abstract Task UnquarantineMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
     public abstract Task DeleteMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
 }

--- a/src/SynapseAdmin/Infrastructure/Gateways/SynapseAdminGateway.cs
+++ b/src/SynapseAdmin/Infrastructure/Gateways/SynapseAdminGateway.cs
@@ -251,6 +251,13 @@ public class SynapseAdminGateway(AuthenticatedHomeserverSynapse synapse) : Matri
         await _synapse.Admin.QuarantineMediaById(serverName, mediaId);
     }
 
+    public override async Task UnquarantineMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default)
+    {
+        var url = $"/_synapse/admin/v1/media/unquarantine/{serverName.UrlEncode()}/{mediaId.UrlEncode()}";
+        var resp = await _synapse.ClientHttpClient.PostAsJsonAsync(url, new { }, cancellationToken: cancellationToken);
+        resp.EnsureSuccessStatusCode();
+    }
+
     public override async Task DeleteMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default)
     {
         await _synapse.Admin.DeleteMediaById(serverName, mediaId);

--- a/src/SynapseAdmin/Interfaces/Gateways/IMatrixGateway.cs
+++ b/src/SynapseAdmin/Interfaces/Gateways/IMatrixGateway.cs
@@ -68,5 +68,6 @@ public interface IMatrixGateway
     Task<SynapseAdminMediaMetadataResponse.MediaInfo?> GetMediaMetadataAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
     Task<SynapseAdminMediaMetadataResponse.MediaInfo?> GetMediaMetadataAsync(MxcUri mxc, CancellationToken cancellationToken = default);
     Task QuarantineMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
+    Task UnquarantineMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
     Task DeleteMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
 }

--- a/src/SynapseAdmin/Interfaces/IMediaService.cs
+++ b/src/SynapseAdmin/Interfaces/IMediaService.cs
@@ -8,5 +8,6 @@ public interface IMediaService
     Task<OperationResult<Stream>> GetMediaStreamAsync(string mxc);
     Task<OperationResult<SynapseAdminMediaMetadataResponse.MediaInfo>> GetMediaMetadataAsync(string mxc);
     Task<OperationResult> QuarantineMediaAsync(string mxc, CancellationToken token = default);
+    Task<OperationResult> UnquarantineMediaAsync(string mxc, CancellationToken token = default);
     Task<OperationResult> DeleteMediaAsync(string mxc, CancellationToken token = default);
 }

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -799,4 +799,19 @@
   <data name="QuarantinedBy" xml:space="preserve">
     <value>Quarantäne durch</value>
   </data>
+  <data name="Unquarantine" xml:space="preserve">
+    <value>Aus Quarantäne nehmen</value>
+  </data>
+  <data name="UnquarantineMediaConfirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie diese Medien aus der Quarantäne nehmen möchten?</value>
+  </data>
+  <data name="UnquarantineMediaTitle" xml:space="preserve">
+    <value>Medien aus Quarantäne nehmen</value>
+  </data>
+  <data name="MediaUnquarantinedSuccessfully" xml:space="preserve">
+    <value>Medien erfolgreich aus der Quarantäne genommen.</value>
+  </data>
+  <data name="ErrorUnquarantiningMedia" xml:space="preserve">
+    <value>Fehler beim Aufheben der Quarantäne der Medien.</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -799,4 +799,19 @@
   <data name="QuarantinedBy" xml:space="preserve">
     <value>Mis en quarantaine par</value>
   </data>
+  <data name="Unquarantine" xml:space="preserve">
+    <value>Sortir de quarantaine</value>
+  </data>
+  <data name="UnquarantineMediaConfirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir sortir ce média de la quarantaine ?</value>
+  </data>
+  <data name="UnquarantineMediaTitle" xml:space="preserve">
+    <value>Sortir le média de la quarantaine</value>
+  </data>
+  <data name="MediaUnquarantinedSuccessfully" xml:space="preserve">
+    <value>Le média a été sorti de la quarantaine avec succès.</value>
+  </data>
+  <data name="ErrorUnquarantiningMedia" xml:space="preserve">
+    <value>Erreur lors de la sortie du média de la quarantaine.</value>
+  </data>
   </root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -800,4 +800,19 @@
   <data name="QuarantinedBy" xml:space="preserve">
     <value>Quarantined by</value>
   </data>
+  <data name="Unquarantine" xml:space="preserve">
+    <value>Unquarantine</value>
+  </data>
+  <data name="UnquarantineMediaConfirmation" xml:space="preserve">
+    <value>Are you sure you want to unquarantine this media?</value>
+  </data>
+  <data name="UnquarantineMediaTitle" xml:space="preserve">
+    <value>Unquarantine Media</value>
+  </data>
+  <data name="MediaUnquarantinedSuccessfully" xml:space="preserve">
+    <value>Media unquarantined successfully.</value>
+  </data>
+  <data name="ErrorUnquarantiningMedia" xml:space="preserve">
+    <value>Error unquarantining media.</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Services/MediaService.cs
+++ b/src/SynapseAdmin/Services/MediaService.cs
@@ -66,6 +66,23 @@ public class MediaService(IMatrixSessionService sessionService, ILogger<MediaSer
         }
     }
 
+    public async Task<OperationResult> UnquarantineMediaAsync(string mxc, CancellationToken token = default)
+    {
+        if (Gateway == null) return OperationResult.Failure(L["NotAuthenticated"]);
+        try
+        {
+            var parsed = MxcUri.Parse(mxc);
+            await Gateway.UnquarantineMediaAsync(parsed.ServerName, parsed.MediaId, token);
+            logger.LogInformation("Successfully unquarantined media {Mxc}", mxc.SanitizeForLogging());
+            return OperationResult.Ok(L["MediaUnquarantinedSuccessfully"]);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error unquarantining media {Mxc}", mxc.SanitizeForLogging());
+            return OperationResult.Failure(L["ErrorUnquarantiningMedia"]);
+        }
+    }
+
     public async Task<OperationResult> DeleteMediaAsync(string mxc, CancellationToken token = default)
     {
         if (Gateway == null) return OperationResult.Failure(L["NotAuthenticated"]);


### PR DESCRIPTION
Resolves #200. Adds the ability to unquarantine media from the user and room details pages. The Unquarantine button replaces the Quarantine button when an item is already quarantined.