### PR TITLE
Feat: Show room avatars on Room Details page

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -43,6 +43,23 @@ else
                     </CardHeaderContent>
                 </MudCardHeader>
                 <MudCardContent>
+                    <div class="d-flex align-center mb-4">
+                        @if (!string.IsNullOrEmpty(room.AvatarUrl))
+                        {
+                            <MudAvatar Size="Size.Large" Class="mr-4">
+                                <MudImage Src="@(room.AvatarUrl.StartsWith("mxc://") ? $"/Media/Avatar?mxc={Uri.EscapeDataString(room.AvatarUrl)}" : room.AvatarUrl)" />
+                            </MudAvatar>
+                        }
+                        else
+                        {
+                            <MudAvatar Color="Color.Primary" Size="Size.Large" Class="mr-4">@(room.Name?.FirstOrDefault() ?? room.RoomId.FirstOrDefault())</MudAvatar>
+                        }
+                        <div>
+                            <MudText Typo="Typo.h6">@(string.IsNullOrEmpty(room.Name) ? room.RoomId : room.Name)</MudText>
+                            <MudText Typo="Typo.body2" Color="Color.Secondary">@room.RoomId</MudText>
+                        </div>
+                    </div>
+
                     <MudList T="string" Dense="true">
                         <MudListItem T="string"><b>@L["ID"]:</b> <MudText Typo="Typo.caption" Style="word-break: break-all;">@room.RoomId</MudText></MudListItem>
                         <MudListItem T="string"><b>@L["Name"]:</b> @(string.IsNullOrEmpty(room.Name) ? L["NoName"] : room.Name)</MudListItem>

--- a/src/SynapseAdmin/Models/Responses/SynapseAdminRoomListResult.cs
+++ b/src/SynapseAdmin/Models/Responses/SynapseAdminRoomListResult.cs
@@ -63,7 +63,7 @@ public class SynapseAdminRoomListResult
         [JsonPropertyName("state_events")]
         public int StateEvents { get; set; }
 
-        [JsonPropertyName("avatar_url")]
+        [JsonPropertyName("avatar")]
         public string? AvatarUrl { get; set; }
 
         [JsonPropertyName("room_type")]


### PR DESCRIPTION
Updated the Room Details page to display the room avatar and fixed the DTO mapping for the Synapse Admin API (which uses 'avatar' instead of 'avatar_url' for rooms).