### PR TITLE
security: run container as non-root app user

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ The easiest way to get started is by using the default `docker-compose.yml` file
 docker compose up -d
 ```
 
+> [!IMPORTANT]
+> **Container Security & Permissions:**
+> The Docker container runs under a non-root user context (`app`, UID `1654`) for safety.
+> - **If using Docker Named Volumes:** Permissions are set automatically.
+> - **If using local Bind Mounts** (as configured in the default `docker-compose.yml`), the host directories **must be writable** by UID `1654`. Run the following command on your host *before* starting the container:
+>   ```bash
+>   mkdir -p logs keys
+>   sudo chown -R 1654:1654 logs keys
+>   ```
+
 This will:
 - Pull the latest image from GHCR.
 - Map port `8080` for the web interface.
@@ -95,7 +105,7 @@ This will:
 - **Encrypt** the persisted keys using the `DP_PASSPHRASE`.
 
 #### Using Docker CLI
-Alternatively, you can run the container directly. Make sure to provide a secure passphrase:
+Alternatively, you can run the container directly. Make sure to provide a secure passphrase, and that the host directories are writable by UID `1654` (as described in the Docker Compose section above):
 
 ```bash
 docker run -d \

--- a/src/SynapseAdmin/Dockerfile
+++ b/src/SynapseAdmin/Dockerfile
@@ -19,4 +19,9 @@ RUN dotnet publish -c Release -o /app
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 COPY --from=build /app .
+
+# Pre-create logs and keys directories and set ownership to non-root app user
+RUN mkdir -p /app/logs /app/keys && chown -R app:app /app/logs /app/keys
+
+USER app
 ENTRYPOINT ["dotnet", "SynapseAdmin.dll"]


### PR DESCRIPTION
This PR updates the Dockerfile to configure the container to run under the built-in non-root 'app' user (UID 1654), pre-creates the logs/keys writeable directories with appropriate ownership, and documents host-side bind mount permission requirements in the README.md.