### PR TITLE
fix: localize form validation in ViewModels

### DIFF
--- a/src/SynapseAdmin/Models/ViewModels/LoginViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/LoginViewModel.cs
@@ -1,3 +1,8 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Localization;
+using SynapseAdmin.Resources;
+
 namespace SynapseAdmin.Models.ViewModels;
 
 public enum LoginMethod
@@ -6,11 +11,52 @@ public enum LoginMethod
     AccessToken
 }
 
-public class LoginViewModel
+public class LoginViewModel : IValidatableObject
 {
     public LoginMethod Method { get; set; } = LoginMethod.Password;
     public string Homeserver { get; set; } = "https://matrix.org";
     public string Username { get; set; } = "";
     public string Password { get; set; } = "";
     public string AccessToken { get; set; } = "";
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        var L = validationContext.GetService(typeof(IStringLocalizer<SharedResources>)) as IStringLocalizer<SharedResources>;
+
+        if (string.IsNullOrWhiteSpace(Homeserver))
+        {
+            yield return new ValidationResult(
+                L?["HomeserverUrlRequired"] ?? "Homeserver URL is required!",
+                new[] { nameof(Homeserver) }
+            );
+        }
+
+        if (Method == LoginMethod.Password)
+        {
+            if (string.IsNullOrWhiteSpace(Username))
+            {
+                yield return new ValidationResult(
+                    L?["UsernameRequired"] ?? "Username is required!",
+                    new[] { nameof(Username) }
+                );
+            }
+            if (string.IsNullOrWhiteSpace(Password))
+            {
+                yield return new ValidationResult(
+                    L?["PasswordRequired"] ?? "Password is required!",
+                    new[] { nameof(Password) }
+                );
+            }
+        }
+        else if (Method == LoginMethod.AccessToken)
+        {
+            if (string.IsNullOrWhiteSpace(AccessToken))
+            {
+                yield return new ValidationResult(
+                    L?["AccessTokenRequired"] ?? "Access token is required!",
+                    new[] { nameof(AccessToken) }
+                );
+            }
+        }
+    }
 }

--- a/src/SynapseAdmin/Models/ViewModels/UserCreateViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/UserCreateViewModel.cs
@@ -1,15 +1,16 @@
 using System.ComponentModel.DataAnnotations;
+using SynapseAdmin.Resources;
 
 namespace SynapseAdmin.Models.ViewModels;
 
 public class UserCreateViewModel
 {
-    [Required]
-    [RegularExpression(@"^@[a-z0-9._=\-/]+:[a-z0-9.-]+\.[a-z]{2,}$", ErrorMessage = "Invalid MXID format")]
+    [Required(ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = "UserIdRequired")]
+    [RegularExpression(@"^@[a-z0-9._=\-/]+:[a-z0-9.-]+\.[a-z]{2,}$", ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = "InvalidMxidFormat")]
     public string UserId { get; set; } = string.Empty;
 
-    [Required]
-    [MinLength(8, ErrorMessage = "Password must be at least 8 characters")]
+    [Required(ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = "PasswordRequired")]
+    [MinLength(8, ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = "PasswordTooShort")]
     public string Password { get; set; } = string.Empty;
 
     public string? DisplayName { get; set; }

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -814,4 +814,22 @@
   <data name="ErrorUnquarantiningMedia" xml:space="preserve">
     <value>Fehler beim Aufheben der Quarantäne der Medien.</value>
   </data>
+  <data name="HomeserverUrlRequired" xml:space="preserve">
+    <value>Homeserver-URL ist erforderlich!</value>
+  </data>
+  <data name="UsernameRequired" xml:space="preserve">
+    <value>Benutzername ist erforderlich!</value>
+  </data>
+  <data name="PasswordRequired" xml:space="preserve">
+    <value>Passwort ist erforderlich!</value>
+  </data>
+  <data name="AccessTokenRequired" xml:space="preserve">
+    <value>Zugriffstoken ist erforderlich!</value>
+  </data>
+  <data name="InvalidMxidFormat" xml:space="preserve">
+    <value>Ungültiges MXID-Format!</value>
+  </data>
+  <data name="PasswordTooShort" xml:space="preserve">
+    <value>Das Passwort muss mindestens 8 Zeichen lang sein!</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -814,4 +814,22 @@
   <data name="ErrorUnquarantiningMedia" xml:space="preserve">
     <value>Erreur lors de la sortie du média de la quarantaine.</value>
   </data>
-  </root>
+  <data name="HomeserverUrlRequired" xml:space="preserve">
+    <value>L'URL du serveur d'accueil est requise !</value>
+  </data>
+  <data name="UsernameRequired" xml:space="preserve">
+    <value>Le nom d'utilisateur est requis !</value>
+  </data>
+  <data name="PasswordRequired" xml:space="preserve">
+    <value>Le mot de passe est requis !</value>
+  </data>
+  <data name="AccessTokenRequired" xml:space="preserve">
+    <value>Le jeton d'accès est requis !</value>
+  </data>
+  <data name="InvalidMxidFormat" xml:space="preserve">
+    <value>Format de MXID invalide !</value>
+  </data>
+  <data name="PasswordTooShort" xml:space="preserve">
+    <value>Le mot de passe doit comporter au moins 8 caractères !</value>
+  </data>
+</root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -830,4 +830,22 @@
   <data name="Suspended" xml:space="preserve">
     <value>Suspended</value>
   </data>
+  <data name="HomeserverUrlRequired" xml:space="preserve">
+    <value>Homeserver URL is required!</value>
+  </data>
+  <data name="UsernameRequired" xml:space="preserve">
+    <value>Username is required!</value>
+  </data>
+  <data name="PasswordRequired" xml:space="preserve">
+    <value>Password is required!</value>
+  </data>
+  <data name="AccessTokenRequired" xml:space="preserve">
+    <value>Access token is required!</value>
+  </data>
+  <data name="InvalidMxidFormat" xml:space="preserve">
+    <value>Invalid MXID format!</value>
+  </data>
+  <data name="PasswordTooShort" xml:space="preserve">
+    <value>Password must be at least 8 characters!</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR adds validation logic to LoginViewModel (implementing IValidatableObject to support conditional password vs access token method validation) and localizes all custom validation error messages for both LoginViewModel and UserCreateViewModel in English, German, and French resource files.