### PR TITLE
feat: background updates management (#182)

### DIFF
--- a/src/SynapseAdmin/Components/Layout/NavMenu.razor
+++ b/src/SynapseAdmin/Components/Layout/NavMenu.razor
@@ -6,6 +6,7 @@
     <MudNavLink Href="federation" Icon="@Icons.Material.Filled.CloudSync">@L["Federation"]</MudNavLink>
     <MudNavLink Href="notices" Icon="@Icons.Material.Filled.Announcement">@L["ServerNotices"]</MudNavLink>
     <MudNavLink Href="tokens" Icon="@Icons.Material.Filled.Key">@L["RegistrationTokens"]</MudNavLink>
+    <MudNavLink Href="background-updates" Icon="@Icons.Material.Filled.SettingsBackupRestore">@L["BackgroundUpdates"]</MudNavLink>
     
     <AuthorizeView>
         <Authorized>

--- a/src/SynapseAdmin/Components/Pages/BackgroundUpdates.razor
+++ b/src/SynapseAdmin/Components/Pages/BackgroundUpdates.razor
@@ -1,0 +1,158 @@
+@page "/background-updates"
+
+@attribute [Authorize]
+
+<PageTitle>@L["BackgroundUpdates"] - SynapseAdmin.NET</PageTitle>
+
+<div class="d-flex align-center mb-6">
+    <MudIcon Icon="@Icons.Material.Filled.SettingsBackupRestore" Size="Size.Large" Class="mr-3" Color="Color.Primary" />
+    <div>
+        <MudText Typo="Typo.h3">@L["BackgroundUpdates"]</MudText>
+        <MudText Typo="Typo.subtitle1" Color="Color.Secondary">@L["BackgroundUpdatesDescription"]</MudText>
+    </div>
+    <MudSpacer />
+    <MudButton Variant="Variant.Outlined" 
+               StartIcon="@Icons.Material.Filled.Refresh" 
+               OnClick="LoadStatus" 
+               Disabled="@isLoading" 
+               Color="Color.Secondary">
+        @L["Refresh"]
+    </MudButton>
+</div>
+
+@if (MatrixSession.Gateway is not { SupportsAdminApi: true })
+{
+    <MudAlert Severity="Severity.Error" Elevation="2" Class="mb-4">
+        @L["BackgroundUpdatesApiRequired"]
+    </MudAlert>
+}
+else if (isLoading && statusResponse == null)
+{
+    <div class="d-flex align-center justify-center my-12">
+        <MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
+    </div>
+}
+else
+{
+    <MudGrid>
+        <!-- Status Card -->
+        <MudItem xs="12" md="6">
+            <MudCard Elevation="3" Style="height: 100%;">
+                <MudCardHeader>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">@L["BackgroundUpdatesStatus"]</MudText>
+                    </CardHeaderContent>
+                </MudCardHeader>
+                <MudCardContent>
+                    <div class="d-flex align-center justify-space-between py-2">
+                        <div>
+                            <MudText Typo="Typo.body1" Inline="true" Class="mr-2">Status:</MudText>
+                            @if (statusResponse != null && statusResponse.Enabled)
+                            {
+                                <MudChip T="string" Color="Color.Success" Size="Size.Small" Variant="Variant.Filled">@L["Active"]</MudChip>
+                            }
+                            else
+                            {
+                                <MudChip T="string" Color="Color.Warning" Size="Size.Small" Variant="Variant.Filled">@L["Paused"]</MudChip>
+                            }
+                        </div>
+                        <MudButton Variant="Variant.Filled" 
+                                   Color="@(statusResponse != null && statusResponse.Enabled ? Color.Warning : Color.Success)" 
+                                   OnClick="ToggleEnabled" 
+                                   Disabled="@isToggling">
+                            @if (isToggling)
+                            {
+                                <MudProgressCircular Class="ms-n1" Size="Size.Small" Indeterminate="true" />
+                            }
+                            else
+                            {
+                                @(statusResponse != null && statusResponse.Enabled ? L["PauseBackgroundUpdates"] : L["ResumeBackgroundUpdates"])
+                              }
+                        </MudButton>
+                    </div>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+
+        <!-- Active Updates Card -->
+        <MudItem xs="12" md="6">
+            <MudCard Elevation="3" Style="height: 100%;">
+                <MudCardHeader>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">@L["ActiveUpdates"]</MudText>
+                    </CardHeaderContent>
+                </MudCardHeader>
+                <MudCardContent>
+                    @if (statusResponse?.CurrentUpdates == null || statusResponse.CurrentUpdates.Count == 0)
+                    {
+                        <div class="d-flex flex-column align-center justify-center py-4">
+                            <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" Size="Size.Large" Class="mb-2" />
+                            <MudText Typo="Typo.body2" Color="Color.Secondary" Align="Align.Center">@L["NoActiveUpdates"]</MudText>
+                        </div>
+                    }
+                    else
+                    {
+                        <MudTable Items="@statusResponse.CurrentUpdates" Elevation="0" Dense="true" Hover="true">
+                            <HeaderContent>
+                                <MudTh>@L["DatabaseName"]</MudTh>
+                                <MudTh>@L["UpdateName"]</MudTh>
+                                <MudTh>@L["ProcessedItems"]</MudTh>
+                                <MudTh>@L["Duration"]</MudTh>
+                                <MudTh>@L["AverageSpeed"]</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="@L["DatabaseName"]">@context.Key</MudTd>
+                                <MudTd DataLabel="@L["UpdateName"]">@context.Value.Name</MudTd>
+                                <MudTd DataLabel="@L["ProcessedItems"]">@context.Value.TotalItemCount</MudTd>
+                                <MudTd DataLabel="@L["Duration"]">@((context.Value.TotalDurationMs / 1000.0).ToString("N1")) s</MudTd>
+                                <MudTd DataLabel="@L["AverageSpeed"]">@(context.Value.AverageItemsPerMs.ToString("N2")) / ms</MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                    }
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+
+        <!-- Manual Jobs Trigger Card -->
+        <MudItem xs="12">
+            <MudCard Elevation="3">
+                <MudCardHeader>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">@L["ManualTriggerJobs"]</MudText>
+                    </CardHeaderContent>
+                </MudCardHeader>
+                <MudCardContent>
+                    <!-- Job 1 -->
+                    <div class="d-flex align-center justify-space-between py-4 border-bottom">
+                        <div style="max-width: 80%;">
+                            <MudText Typo="Typo.subtitle1" Class="fw-bold">@L["RecalculateRoomStats"]</MudText>
+                            <MudText Typo="Typo.body2" Color="Color.Secondary">@L["RecalculateRoomStatsDescription"]</MudText>
+                        </div>
+                        <MudButton Variant="Variant.Filled" 
+                                   Color="Color.Primary" 
+                                   OnClick='() => TriggerJob("populate_stats_process_rooms", L["RecalculateRoomStats"])'
+                                   Disabled="@isTriggering">
+                            @L["Trigger"]
+                        </MudButton>
+                    </div>
+
+                    <MudDivider />
+
+                    <!-- Job 2 -->
+                    <div class="d-flex align-center justify-space-between py-4">
+                        <div style="max-width: 80%;">
+                            <MudText Typo="Typo.subtitle1" Class="fw-bold">@L["RegenerateUserDirectory"]</MudText>
+                            <MudText Typo="Typo.body2" Color="Color.Secondary">@L["RegenerateUserDirectoryDescription"]</MudText>
+                        </div>
+                        <MudButton Variant="Variant.Filled" 
+                                   Color="Color.Primary" 
+                                   OnClick='() => TriggerJob("regenerate_directory", L["RegenerateUserDirectory"])'
+                                   Disabled="@isTriggering">
+                            @L["Trigger"]
+                        </MudButton>
+                    </div>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+    </MudGrid>
+}

--- a/src/SynapseAdmin/Components/Pages/BackgroundUpdates.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/BackgroundUpdates.razor.cs
@@ -1,0 +1,122 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using SynapseAdmin.Interfaces;
+using SynapseAdmin.Models.Responses;
+
+namespace SynapseAdmin.Components.Pages;
+
+public partial class BackgroundUpdates : IDisposable
+{
+    [Inject]
+    public IMatrixSessionService MatrixSession { get; set; } = null!;
+
+    [Inject]
+    public IBackgroundUpdatesService BackgroundUpdatesService { get; set; } = null!;
+
+    [Inject]
+    public ISnackbar Snackbar { get; set; } = null!;
+
+    [Inject]
+    public IDialogService DialogService { get; set; } = null!;
+
+    private SynapseAdminBackgroundUpdatesStatusResponse? statusResponse;
+    private bool isLoading = true;
+    private bool isToggling = false;
+    private bool isTriggering = false;
+
+    private readonly CancellationTokenSource _cts = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (MatrixSession.Gateway is { SupportsAdminApi: true })
+        {
+            await LoadStatus();
+        }
+    }
+
+    private async Task LoadStatus()
+    {
+        isLoading = true;
+        var result = await BackgroundUpdatesService.GetStatusAsync(_cts.Token);
+        if (result.Success)
+        {
+            statusResponse = result.Data;
+        }
+        else if (result.Severity != Severity.Normal)
+        {
+            Snackbar.Add(result.Message, result.Severity);
+        }
+        isLoading = false;
+    }
+
+    private async Task ToggleEnabled()
+    {
+        if (statusResponse == null || isToggling) return;
+
+        bool nextState = !statusResponse.Enabled;
+        string confirmTitle = nextState ? L["ResumeUpdatesConfirmation"] : L["PauseUpdatesConfirmation"];
+        string confirmMessage = nextState ? L["ResumeUpdatesMessage"] : L["PauseUpdatesWarning"];
+        string yesBtn = nextState ? L["ResumeBackgroundUpdates"] : L["PauseBackgroundUpdates"];
+
+        bool? confirmed = await DialogService.ShowMessageBoxAsync(
+            confirmTitle,
+            confirmMessage,
+            yesText: yesBtn,
+            cancelText: L["Cancel"]
+        );
+
+        if (confirmed == true)
+        {
+            isToggling = true;
+            var result = await BackgroundUpdatesService.SetEnabledAsync(nextState, _cts.Token);
+            if (result.Success && result.Data != null)
+            {
+                if (statusResponse != null)
+                {
+                    statusResponse.Enabled = result.Data.Enabled;
+                }
+                Snackbar.Add(L["BackgroundUpdatesStatus"] + ": " + (result.Data.Enabled ? L["Active"] : L["Paused"]), Severity.Success);
+                await LoadStatus();
+            }
+            else if (result.Severity != Severity.Normal)
+            {
+                Snackbar.Add(result.Message, result.Severity);
+            }
+            isToggling = false;
+        }
+    }
+
+    private async Task TriggerJob(string jobName, string displayName)
+    {
+        if (isTriggering) return;
+
+        bool? confirmed = await DialogService.ShowMessageBoxAsync(
+            L["TriggerJobConfirmation"],
+            string.Format(L["TriggerJobMessage"], displayName),
+            yesText: L["Trigger"],
+            cancelText: L["Cancel"]
+        );
+
+        if (confirmed == true)
+        {
+            isTriggering = true;
+            var result = await BackgroundUpdatesService.StartJobAsync(jobName, _cts.Token);
+            if (result.Success)
+            {
+                Snackbar.Add(result.Message, Severity.Success);
+                await LoadStatus();
+            }
+            else if (result.Severity != Severity.Normal)
+            {
+                Snackbar.Add(result.Message, result.Severity);
+            }
+            isTriggering = false;
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
+    }
+}

--- a/src/SynapseAdmin/Infrastructure/Gateways/MatrixAuthGateway.cs
+++ b/src/SynapseAdmin/Infrastructure/Gateways/MatrixAuthGateway.cs
@@ -84,4 +84,7 @@ internal class GenericMatrixGateway(AuthenticatedHomeserverGeneric homeserver) :
     public override Task QuarantineMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     public override Task UnquarantineMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     public override Task DeleteMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<SynapseAdminBackgroundUpdatesStatusResponse?> GetBackgroundUpdatesStatusAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException("Background updates are only supported for Synapse.");
+    public override Task<SynapseAdminBackgroundUpdatesEnabledResponse?> SetBackgroundUpdatesEnabledAsync(bool enabled, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task StartBackgroundUpdatesJobAsync(string jobName, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 }

--- a/src/SynapseAdmin/Infrastructure/Gateways/MatrixGatewayBase.cs
+++ b/src/SynapseAdmin/Infrastructure/Gateways/MatrixGatewayBase.cs
@@ -123,4 +123,9 @@ public abstract class MatrixGatewayBase(AuthenticatedHomeserverGeneric homeserve
         var mxc = LibMatrix.StructuredData.MxcUri.Parse(mxcUri);
         await DeleteMediaAsync(mxc.ServerName, mxc.MediaId, cancellationToken);
     }
+
+    // --- Background Updates ---
+    public abstract Task<SynapseAdminBackgroundUpdatesStatusResponse?> GetBackgroundUpdatesStatusAsync(CancellationToken cancellationToken = default);
+    public abstract Task<SynapseAdminBackgroundUpdatesEnabledResponse?> SetBackgroundUpdatesEnabledAsync(bool enabled, CancellationToken cancellationToken = default);
+    public abstract Task StartBackgroundUpdatesJobAsync(string jobName, CancellationToken cancellationToken = default);
 }

--- a/src/SynapseAdmin/Infrastructure/Gateways/SynapseAdminGateway.cs
+++ b/src/SynapseAdmin/Infrastructure/Gateways/SynapseAdminGateway.cs
@@ -312,4 +312,24 @@ public class SynapseAdminGateway(AuthenticatedHomeserverSynapse synapse) : Matri
     {
         await _synapse.Admin.DeleteMediaById(serverName, mediaId);
     }
+
+    // --- Background Updates ---
+
+    public override async Task<SynapseAdminBackgroundUpdatesStatusResponse?> GetBackgroundUpdatesStatusAsync(CancellationToken cancellationToken = default)
+    {
+        return await _synapse.ClientHttpClient.GetFromJsonAsync<SynapseAdminBackgroundUpdatesStatusResponse>("/_synapse/admin/v1/background_updates/status", cancellationToken: cancellationToken);
+    }
+
+    public override async Task<SynapseAdminBackgroundUpdatesEnabledResponse?> SetBackgroundUpdatesEnabledAsync(bool enabled, CancellationToken cancellationToken = default)
+    {
+        var resp = await _synapse.ClientHttpClient.PostAsJsonAsync("/_synapse/admin/v1/background_updates/enabled", new { enabled }, cancellationToken: cancellationToken);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<SynapseAdminBackgroundUpdatesEnabledResponse>(cancellationToken: cancellationToken);
+    }
+
+    public override async Task StartBackgroundUpdatesJobAsync(string jobName, CancellationToken cancellationToken = default)
+    {
+        var resp = await _synapse.ClientHttpClient.PostAsJsonAsync("/_synapse/admin/v1/background_updates/start_job", new { job_name = jobName }, cancellationToken: cancellationToken);
+        resp.EnsureSuccessStatusCode();
+    }
 }

--- a/src/SynapseAdmin/Interfaces/Gateways/IMatrixGateway.cs
+++ b/src/SynapseAdmin/Interfaces/Gateways/IMatrixGateway.cs
@@ -70,4 +70,9 @@ public interface IMatrixGateway
     Task UnquarantineMediaAsync(string mxcUri, CancellationToken cancellationToken = default);
     Task DeleteMediaAsync(string serverName, string mediaId, CancellationToken cancellationToken = default);
     Task DeleteMediaAsync(string mxcUri, CancellationToken cancellationToken = default);
+
+    // --- Background Updates ---
+    Task<SynapseAdminBackgroundUpdatesStatusResponse?> GetBackgroundUpdatesStatusAsync(CancellationToken cancellationToken = default);
+    Task<SynapseAdminBackgroundUpdatesEnabledResponse?> SetBackgroundUpdatesEnabledAsync(bool enabled, CancellationToken cancellationToken = default);
+    Task StartBackgroundUpdatesJobAsync(string jobName, CancellationToken cancellationToken = default);
 }

--- a/src/SynapseAdmin/Interfaces/IBackgroundUpdatesService.cs
+++ b/src/SynapseAdmin/Interfaces/IBackgroundUpdatesService.cs
@@ -1,0 +1,11 @@
+using SynapseAdmin.Models;
+using SynapseAdmin.Models.Responses;
+
+namespace SynapseAdmin.Interfaces;
+
+public interface IBackgroundUpdatesService
+{
+    Task<OperationResult<SynapseAdminBackgroundUpdatesStatusResponse>> GetStatusAsync(CancellationToken token = default);
+    Task<OperationResult<SynapseAdminBackgroundUpdatesEnabledResponse>> SetEnabledAsync(bool enabled, CancellationToken token = default);
+    Task<OperationResult> StartJobAsync(string jobName, CancellationToken token = default);
+}

--- a/src/SynapseAdmin/Models/Responses/SynapseAdminBackgroundUpdatesEnabledResponse.cs
+++ b/src/SynapseAdmin/Models/Responses/SynapseAdminBackgroundUpdatesEnabledResponse.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace SynapseAdmin.Models.Responses;
+
+public class SynapseAdminBackgroundUpdatesEnabledResponse
+{
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+}

--- a/src/SynapseAdmin/Models/Responses/SynapseAdminBackgroundUpdatesStatusResponse.cs
+++ b/src/SynapseAdmin/Models/Responses/SynapseAdminBackgroundUpdatesStatusResponse.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace SynapseAdmin.Models.Responses;
+
+public class SynapseAdminBackgroundUpdatesStatusResponse
+{
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+
+    [JsonPropertyName("current_updates")]
+    public Dictionary<string, CurrentBackgroundUpdate>? CurrentUpdates { get; set; }
+
+    public class CurrentBackgroundUpdate
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("total_item_count")]
+        public long TotalItemCount { get; set; }
+
+        [JsonPropertyName("total_duration_ms")]
+        public double TotalDurationMs { get; set; }
+
+        [JsonPropertyName("average_items_per_ms")]
+        public double AverageItemsPerMs { get; set; }
+    }
+}

--- a/src/SynapseAdmin/Program.cs
+++ b/src/SynapseAdmin/Program.cs
@@ -64,6 +64,7 @@ builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IFederationService, FederationService>();
 builder.Services.AddScoped<IEventReportService, EventReportService>();
 builder.Services.AddScoped<IRegistrationTokenService, RegistrationTokenService>();
+builder.Services.AddScoped<IBackgroundUpdatesService, BackgroundUpdatesService>();
 builder.Services.AddScoped<IThemeService, ThemeService>();
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddScoped<AuthenticationStateProvider, MatrixAuthenticationStateProvider>();

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -832,4 +832,100 @@
   <data name="PasswordTooShort" xml:space="preserve">
     <value>Das Passwort muss mindestens 8 Zeichen lang sein!</value>
   </data>
+  <data name="BackgroundUpdates" xml:space="preserve">
+    <value>Hintergrund-Aktualisierungen</value>
+  </data>
+  <data name="BackgroundUpdatesDescription" xml:space="preserve">
+    <value>Datenbank-Hintergrund-Aktualisierungen von Synapse verwalten und überwachen.</value>
+  </data>
+  <data name="BackgroundUpdatesApiRequired" xml:space="preserve">
+    <value>Die Hintergrund-Aktualisierungs-API erfordert Zugriff auf die Synapse-Admin-API.</value>
+  </data>
+  <data name="BackgroundUpdatesStatus" xml:space="preserve">
+    <value>Hintergrund-Aktualisierungsstatus</value>
+  </data>
+  <data name="Paused" xml:space="preserve">
+    <value>Pausiert</value>
+  </data>
+  <data name="PauseBackgroundUpdates" xml:space="preserve">
+    <value>Updates pausieren</value>
+  </data>
+  <data name="ResumeBackgroundUpdates" xml:space="preserve">
+    <value>Updates fortsetzen</value>
+  </data>
+  <data name="PauseUpdatesConfirmation" xml:space="preserve">
+    <value>Updates pausieren bestätigen</value>
+  </data>
+  <data name="PauseUpdatesWarning" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie die Datenbank-Hintergrundaktualisierungen pausieren möchten? Längeres Pausieren kann die Leistung von Synapse beeinträchtigen.</value>
+  </data>
+  <data name="ResumeUpdatesConfirmation" xml:space="preserve">
+    <value>Updates fortsetzen bestätigen</value>
+  </data>
+  <data name="ResumeUpdatesMessage" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie die Datenbank-Hintergrundaktualisierungen fortsetzen möchten?</value>
+  </data>
+  <data name="ActiveUpdates" xml:space="preserve">
+    <value>Aktive Aktualisierungen</value>
+  </data>
+  <data name="NoActiveUpdates" xml:space="preserve">
+    <value>Derzeit laufen keine aktiven Datenbank-Aktualisierungen.</value>
+  </data>
+  <data name="DatabaseName" xml:space="preserve">
+    <value>Datenbank</value>
+  </data>
+  <data name="UpdateName" xml:space="preserve">
+    <value>Aktualisierungs-Job</value>
+  </data>
+  <data name="ProcessedItems" xml:space="preserve">
+    <value>Verarbeitete Elemente</value>
+  </data>
+  <data name="Duration" xml:space="preserve">
+    <value>Dauer</value>
+  </data>
+  <data name="AverageSpeed" xml:space="preserve">
+    <value>Durchschnittliche Geschwindigkeit</value>
+  </data>
+  <data name="ManualTriggerJobs" xml:space="preserve">
+    <value>Manuelles Auslösen von Jobs</value>
+  </data>
+  <data name="RecalculateRoomStats" xml:space="preserve">
+    <value>Raumstatistiken neu berechnen</value>
+  </data>
+  <data name="RecalculateRoomStatsDescription" xml:space="preserve">
+    <value>Plant eine sofortige, datenbankweite Neuberechnung von Statistiken (wie Benutzer- und Nachrichtenzahlen) für alle Räume.</value>
+  </data>
+  <data name="RegenerateUserDirectory" xml:space="preserve">
+    <value>Benutzerverzeichnis neu generieren</value>
+  </data>
+  <data name="RegenerateUserDirectoryDescription" xml:space="preserve">
+    <value>Plant eine sofortige Neuerstellung des Benutzerverzeichnis-Index, falls dieser veraltet oder asynchron ist.</value>
+  </data>
+  <data name="TriggerJobConfirmation" xml:space="preserve">
+    <value>Job-Auslösung bestätigen</value>
+  </data>
+  <data name="TriggerJobMessage" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie den Hintergrundjob '{0}' sofort ausführen möchten? Dies kann je nach Datenbankgröße erhebliche Ressourcen verbrauchen.</value>
+  </data>
+  <data name="Trigger" xml:space="preserve">
+    <value>Auslösen</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Ja</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>Nein</value>
+  </data>
+  <data name="ErrorFetchingBackgroundUpdatesStatus" xml:space="preserve">
+    <value>Fehler beim Abrufen des Hintergrundaktualisierungsstatus.</value>
+  </data>
+  <data name="ErrorTogglingBackgroundUpdates" xml:space="preserve">
+    <value>Fehler beim Umschalten des Aktivierungsstatus der Hintergrundaktualisierungen.</value>
+  </data>
+  <data name="ErrorStartingBackgroundUpdateJob" xml:space="preserve">
+    <value>Fehler beim Starten des Hintergrundaktualisierungs-Jobs.</value>
+  </data>
+  <data name="BackgroundUpdateJobStarted" xml:space="preserve">
+    <value>Hintergrundaktualisierungs-Job erfolgreich gestartet.</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -832,4 +832,100 @@
   <data name="PasswordTooShort" xml:space="preserve">
     <value>Le mot de passe doit comporter au moins 8 caractères !</value>
   </data>
+  <data name="BackgroundUpdates" xml:space="preserve">
+    <value>Mises à jour en arrière-plan</value>
+  </data>
+  <data name="BackgroundUpdatesDescription" xml:space="preserve">
+    <value>Gérer et surveiller les mises à jour en arrière-plan de la base de données exécutées par Synapse.</value>
+  </data>
+  <data name="BackgroundUpdatesApiRequired" xml:space="preserve">
+    <value>L'API des mises à jour en arrière-plan nécessite l'accès à l'API d'administration de Synapse.</value>
+  </data>
+  <data name="BackgroundUpdatesStatus" xml:space="preserve">
+    <value>Statut des mises à jour en arrière-plan</value>
+  </data>
+  <data name="Paused" xml:space="preserve">
+    <value>Suspendu</value>
+  </data>
+  <data name="PauseBackgroundUpdates" xml:space="preserve">
+    <value>Mettre en pause</value>
+  </data>
+  <data name="ResumeBackgroundUpdates" xml:space="preserve">
+    <value>Reprendre les mises à jour</value>
+  </data>
+  <data name="PauseUpdatesConfirmation" xml:space="preserve">
+    <value>Confirmer la mise en pause</value>
+  </data>
+  <data name="PauseUpdatesWarning" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir suspendre les mises à jour en arrière-plan de la base de données ? Les suspendre trop longtemps peut dégrader les performances de Synapse.</value>
+  </data>
+  <data name="ResumeUpdatesConfirmation" xml:space="preserve">
+    <value>Confirmer la reprise</value>
+  </data>
+  <data name="ResumeUpdatesMessage" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir reprendre les mises à jour en arrière-plan de la base de données ?</value>
+  </data>
+  <data name="ActiveUpdates" xml:space="preserve">
+    <value>Mises à jour actives</value>
+  </data>
+  <data name="NoActiveUpdates" xml:space="preserve">
+    <value>Aucune mise à jour de base de données n'est en cours en ce moment.</value>
+  </data>
+  <data name="DatabaseName" xml:space="preserve">
+    <value>Base de données</value>
+  </data>
+  <data name="UpdateName" xml:space="preserve">
+    <value>Tâche de mise à jour</value>
+  </data>
+  <data name="ProcessedItems" xml:space="preserve">
+    <value>Éléments traités</value>
+  </data>
+  <data name="Duration" xml:space="preserve">
+    <value>Durée</value>
+  </data>
+  <data name="AverageSpeed" xml:space="preserve">
+    <value>Vitesse moyenne</value>
+  </data>
+  <data name="ManualTriggerJobs" xml:space="preserve">
+    <value>Déclenchement manuel de tâches</value>
+  </data>
+  <data name="RecalculateRoomStats" xml:space="preserve">
+    <value>Recalculer les statistiques des salons</value>
+  </data>
+  <data name="RecalculateRoomStatsDescription" xml:space="preserve">
+    <value>Planifie un recalcul immédiat des statistiques (comme le nombre d'utilisateurs et de messages) de tous les salons dans la base de données.</value>
+  </data>
+  <data name="RegenerateUserDirectory" xml:space="preserve">
+    <value>Régénérer l'annuaire des utilisateurs</value>
+  </data>
+  <data name="RegenerateUserDirectoryDescription" xml:space="preserve">
+    <value>Planifie une reconstruction immédiate de l'index de l'annuaire des utilisateurs s'il est devenu obsolète ou désynchronisé.</value>
+  </data>
+  <data name="TriggerJobConfirmation" xml:space="preserve">
+    <value>Confirmer le déclenchement de la tâche</value>
+  </data>
+  <data name="TriggerJobMessage" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir déclencher immédiatement la tâche en arrière-plan '{0}' ? Cela peut consommer des ressources de la base de données en fonction de sa taille.</value>
+  </data>
+  <data name="Trigger" xml:space="preserve">
+    <value>Déclencher</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Oui</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>Non</value>
+  </data>
+  <data name="ErrorFetchingBackgroundUpdatesStatus" xml:space="preserve">
+    <value>Erreur lors de la récupération du statut des mises à jour en arrière-plan.</value>
+  </data>
+  <data name="ErrorTogglingBackgroundUpdates" xml:space="preserve">
+    <value>Erreur lors du basculement du statut d'activation des mises à jour.</value>
+  </data>
+  <data name="ErrorStartingBackgroundUpdateJob" xml:space="preserve">
+    <value>Erreur lors du démarrage de la tâche de mise à jour en arrière-plan.</value>
+  </data>
+  <data name="BackgroundUpdateJobStarted" xml:space="preserve">
+    <value>La tâche de mise à jour en arrière-plan a démarré avec succès.</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -848,4 +848,100 @@
   <data name="PasswordTooShort" xml:space="preserve">
     <value>Password must be at least 8 characters!</value>
   </data>
+  <data name="BackgroundUpdates" xml:space="preserve">
+    <value>Background Updates</value>
+  </data>
+  <data name="BackgroundUpdatesDescription" xml:space="preserve">
+    <value>Manage and monitor database background updates executed by Synapse.</value>
+  </data>
+  <data name="BackgroundUpdatesApiRequired" xml:space="preserve">
+    <value>The Background Updates API requires Synapse Admin API access.</value>
+  </data>
+  <data name="BackgroundUpdatesStatus" xml:space="preserve">
+    <value>Background Updates Status</value>
+  </data>
+  <data name="Paused" xml:space="preserve">
+    <value>Paused</value>
+  </data>
+  <data name="PauseBackgroundUpdates" xml:space="preserve">
+    <value>Pause Updates</value>
+  </data>
+  <data name="ResumeBackgroundUpdates" xml:space="preserve">
+    <value>Resume Updates</value>
+  </data>
+  <data name="PauseUpdatesConfirmation" xml:space="preserve">
+    <value>Pause Updates Confirmation</value>
+  </data>
+  <data name="PauseUpdatesWarning" xml:space="preserve">
+    <value>Are you sure you want to pause database background updates? Keeping updates paused for long periods can severely impact homeserver performance.</value>
+  </data>
+  <data name="ResumeUpdatesConfirmation" xml:space="preserve">
+    <value>Resume Updates Confirmation</value>
+  </data>
+  <data name="ResumeUpdatesMessage" xml:space="preserve">
+    <value>Are you sure you want to resume database background updates?</value>
+  </data>
+  <data name="ActiveUpdates" xml:space="preserve">
+    <value>Active Updates</value>
+  </data>
+  <data name="NoActiveUpdates" xml:space="preserve">
+    <value>No active database updates are running at this time.</value>
+  </data>
+  <data name="DatabaseName" xml:space="preserve">
+    <value>Database</value>
+  </data>
+  <data name="UpdateName" xml:space="preserve">
+    <value>Update Job</value>
+  </data>
+  <data name="ProcessedItems" xml:space="preserve">
+    <value>Items Processed</value>
+  </data>
+  <data name="Duration" xml:space="preserve">
+    <value>Duration</value>
+  </data>
+  <data name="AverageSpeed" xml:space="preserve">
+    <value>Average Speed</value>
+  </data>
+  <data name="ManualTriggerJobs" xml:space="preserve">
+    <value>Manual Trigger Jobs</value>
+  </data>
+  <data name="RecalculateRoomStats" xml:space="preserve">
+    <value>Recalculate Room Statistics</value>
+  </data>
+  <data name="RecalculateRoomStatsDescription" xml:space="preserve">
+    <value>Schedules an immediate database recalculation of room statistics (message counts, user counts, etc.).</value>
+  </data>
+  <data name="RegenerateUserDirectory" xml:space="preserve">
+    <value>Regenerate User Directory</value>
+  </data>
+  <data name="RegenerateUserDirectoryDescription" xml:space="preserve">
+    <value>Schedules an immediate rebuild of the user directory index if it has become stale or out of sync.</value>
+  </data>
+  <data name="TriggerJobConfirmation" xml:space="preserve">
+    <value>Trigger Job Confirmation</value>
+  </data>
+  <data name="TriggerJobMessage" xml:space="preserve">
+    <value>Are you sure you want to trigger the background job '{0}' immediately? This can consume database resources depending on your database size.</value>
+  </data>
+  <data name="Trigger" xml:space="preserve">
+    <value>Trigger</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Yes</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="ErrorFetchingBackgroundUpdatesStatus" xml:space="preserve">
+    <value>Error fetching background updates status.</value>
+  </data>
+  <data name="ErrorTogglingBackgroundUpdates" xml:space="preserve">
+    <value>Error toggling background updates enabled state.</value>
+  </data>
+  <data name="ErrorStartingBackgroundUpdateJob" xml:space="preserve">
+    <value>Error starting background update job.</value>
+  </data>
+  <data name="BackgroundUpdateJobStarted" xml:space="preserve">
+    <value>Background update job started successfully.</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Services/BackgroundUpdatesService.cs
+++ b/src/SynapseAdmin/Services/BackgroundUpdatesService.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Localization;
+using SynapseAdmin.Interfaces;
+using SynapseAdmin.Interfaces.Gateways;
+using SynapseAdmin.Models;
+using SynapseAdmin.Models.Responses;
+using SynapseAdmin.Resources;
+
+namespace SynapseAdmin.Services;
+
+public class BackgroundUpdatesService(
+    IMatrixSessionService sessionService,
+    ILogger<BackgroundUpdatesService> logger,
+    IStringLocalizer<SharedResources> L) : IBackgroundUpdatesService
+{
+    private IMatrixGateway? Gateway => sessionService.Gateway;
+
+    public async Task<OperationResult<SynapseAdminBackgroundUpdatesStatusResponse>> GetStatusAsync(CancellationToken token = default)
+    {
+        if (Gateway == null) return OperationResult<SynapseAdminBackgroundUpdatesStatusResponse>.Failure(L["NotAuthenticated"]);
+        try
+        {
+            var status = await Gateway.GetBackgroundUpdatesStatusAsync(token);
+            if (status == null) return OperationResult<SynapseAdminBackgroundUpdatesStatusResponse>.Failure(L["ErrorFetchingBackgroundUpdatesStatus"]);
+            return OperationResult<SynapseAdminBackgroundUpdatesStatusResponse>.Ok(status);
+        }
+        catch (OperationCanceledException)
+        {
+            return OperationResult<SynapseAdminBackgroundUpdatesStatusResponse>.Cancelled();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error fetching background updates status");
+            return OperationResult<SynapseAdminBackgroundUpdatesStatusResponse>.Failure(L["ErrorFetchingBackgroundUpdatesStatus"]);
+        }
+    }
+
+    public async Task<OperationResult<SynapseAdminBackgroundUpdatesEnabledResponse>> SetEnabledAsync(bool enabled, CancellationToken token = default)
+    {
+        if (Gateway == null) return OperationResult<SynapseAdminBackgroundUpdatesEnabledResponse>.Failure(L["NotAuthenticated"]);
+        try
+        {
+            var result = await Gateway.SetBackgroundUpdatesEnabledAsync(enabled, token);
+            if (result == null) return OperationResult<SynapseAdminBackgroundUpdatesEnabledResponse>.Failure(L["ErrorTogglingBackgroundUpdates"]);
+            return OperationResult<SynapseAdminBackgroundUpdatesEnabledResponse>.Ok(result);
+        }
+        catch (OperationCanceledException)
+        {
+            return OperationResult<SynapseAdminBackgroundUpdatesEnabledResponse>.Cancelled();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error toggling background updates enabled state to {Enabled}", enabled);
+            return OperationResult<SynapseAdminBackgroundUpdatesEnabledResponse>.Failure(L["ErrorTogglingBackgroundUpdates"]);
+        }
+    }
+
+    public async Task<OperationResult> StartJobAsync(string jobName, CancellationToken token = default)
+    {
+        if (Gateway == null) return OperationResult.Failure(L["NotAuthenticated"]);
+        try
+        {
+            await Gateway.StartBackgroundUpdatesJobAsync(jobName, token);
+            return OperationResult.Ok(L["BackgroundUpdateJobStarted"]);
+        }
+        catch (OperationCanceledException)
+        {
+            return OperationResult.Cancelled();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error starting background updates job {JobName}", jobName);
+            return OperationResult.Failure(L["ErrorStartingBackgroundUpdateJob"]);
+        }
+    }
+}


### PR DESCRIPTION
This PR implements Background Updates Management, allowing administrators to monitor database background updates, pause/resume updates, and manually trigger room statistics recalculation or user directory regeneration.
Closes #182 