### PR TITLE
feat: room history purging (#183)

### DIFF
--- a/src/SynapseAdmin/Components/Pages/PurgeHistoryDialog.razor
+++ b/src/SynapseAdmin/Components/Pages/PurgeHistoryDialog.razor
@@ -1,0 +1,61 @@
+@using Microsoft.Extensions.Localization
+@using SynapseAdmin.Resources
+@inject IStringLocalizer<SharedResources> L
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.CleaningServices" Class="mr-3 mb-n1" />
+            @L["PurgeHistory"]
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Class="mb-4">
+            @L["PurgeHistoryWarning"]
+        </MudAlert>
+
+        <MudForm @ref="form" @bind-IsValid="@success">
+            <MudRadioGroup T="string" @bind-Value="purgeType" Class="mb-4 d-flex flex-column">
+                <MudRadio Value="@("date")" Color="Color.Primary">@L["PurgeUpToDate"]</MudRadio>
+                <MudRadio Value="@("event")" Color="Color.Primary">@L["PurgeUpToEvent"]</MudRadio>
+            </MudRadioGroup>
+
+            @if (purgeType == "date")
+            {
+                <MudGrid>
+                    <MudItem xs="12" sm="6">
+                        <MudDatePicker Label="@L["SelectDate"]" @bind-Date="selectedDate" Required="true" RequiredError="@L["PurgeUpToRequired"]" />
+                    </MudItem>
+                    <MudItem xs="12" sm="6">
+                        <MudTimePicker Label="@L["SelectTime"]" @bind-Time="selectedTime" Required="true" RequiredError="@L["PurgeUpToRequired"]" />
+                    </MudItem>
+                </MudGrid>
+            }
+            else
+            {
+                <MudTextField T="string" Label="@L["EventId"]" @bind-Value="eventId" Required="true" RequiredError="@L["PurgeUpToRequired"]" />
+            }
+
+            <div class="mt-6">
+                <MudSwitch T="bool" Label="@L["DeleteLocalEvents"]" @bind-Value="deleteLocalEvents" Color="Color.Primary" />
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="d-block mt-n2 ml-3">
+                    @L["DeleteLocalEventsHelp"]
+                </MudText>
+            </div>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">@L["Cancel"]</MudButton>
+        <MudButton Color="Color.Error" Variant="Variant.Filled" OnClick="Submit" Disabled="@(!success || loading)">
+            @if (loading)
+            {
+                <MudProgressCircular Class="ms-n1" Size="Size.Small" Indeterminate="true" />
+                <MudText Class="ms-2">@L["Loading"]</MudText>
+            }
+            else
+            {
+                @L["PurgeHistory"]
+            }
+        </MudButton>
+    </DialogActions>
+</MudDialog>

--- a/src/SynapseAdmin/Components/Pages/PurgeHistoryDialog.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/PurgeHistoryDialog.razor.cs
@@ -1,0 +1,97 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using SynapseAdmin.Interfaces;
+using SynapseAdmin.Models.Requests;
+using System;
+using System.Threading.Tasks;
+
+namespace SynapseAdmin.Components.Pages;
+
+public partial class PurgeHistoryDialog
+{
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [Inject] private IRoomService RoomService { get; set; } = default!;
+    [Inject] private ISnackbar Snackbar { get; set; } = default!;
+
+    [Parameter] public string RoomId { get; set; } = string.Empty;
+    [Parameter] public string? PreselectedEventId { get; set; }
+    [Parameter] public DateTimeOffset? PreselectedTimestamp { get; set; }
+
+    private MudForm form = default!;
+    private bool success;
+    private bool loading;
+
+    private string purgeType = "date";
+    private DateTime? selectedDate = DateTime.Today;
+    private TimeSpan? selectedTime = DateTime.Now.TimeOfDay;
+    private string? eventId;
+    private bool deleteLocalEvents;
+
+    protected override void OnInitialized()
+    {
+        if (!string.IsNullOrEmpty(PreselectedEventId))
+        {
+            purgeType = "event";
+            eventId = PreselectedEventId;
+        }
+        else if (PreselectedTimestamp.HasValue)
+        {
+            purgeType = "date";
+            selectedDate = PreselectedTimestamp.Value.LocalDateTime.Date;
+            selectedTime = PreselectedTimestamp.Value.LocalDateTime.TimeOfDay;
+        }
+    }
+
+    private async Task Submit()
+    {
+        await form.ValidateAsync();
+
+        if (form.IsValid)
+        {
+            var request = new SynapseAdminPurgeHistoryRequest
+            {
+                DeleteLocalEvents = deleteLocalEvents
+            };
+
+            if (purgeType == "date")
+            {
+                if (selectedDate == null || selectedTime == null)
+                {
+                    Snackbar.Add(L["InvalidDateOrTime"], Severity.Warning);
+                    return;
+                }
+
+                var localDateTime = selectedDate.Value.Date.Add(selectedTime.Value);
+                var dto = new DateTimeOffset(localDateTime, TimeZoneInfo.Local.GetUtcOffset(localDateTime));
+                request.PurgeUpToTs = dto.ToUnixTimeMilliseconds();
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(eventId))
+                {
+                    Snackbar.Add(L["PurgeUpToRequired"], Severity.Warning);
+                    return;
+                }
+                request.PurgeUpToEventId = eventId.Trim();
+            }
+
+            loading = true;
+            var result = await RoomService.PurgeRoomHistoryAsync(RoomId, request);
+            loading = false;
+
+            if (result.Success && result.Data != null)
+            {
+                RoomService.SetActivePurgeId(RoomId, result.Data.PurgeId);
+                Snackbar.Add(result.Message, result.Severity);
+                MudDialog.Close(DialogResult.Ok(result.Data.PurgeId));
+            }
+            else
+            {
+                Snackbar.Add(result.Message, result.Severity);
+            }
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -34,6 +34,37 @@ else
         </MudAlert>
     }
 
+    @if (!string.IsNullOrEmpty(activePurgeId))
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Filled" Class="mb-4 d-flex align-center justify-space-between">
+            <div class="d-flex flex-column">
+                <MudText Typo="Typo.body1"><b>@L["PurgeInProgress"]:</b> @L["PurgeInProgressDescription"]</MudText>
+                @if (!string.IsNullOrEmpty(activePurgeStatus))
+                {
+                    <MudText Typo="Typo.body2">
+                        @L["PurgeStatus"]: 
+                        @if (activePurgeStatus == "active")
+                        {
+                            <MudChip T="string" Color="Color.Info" Size="Size.Small" Variant="Variant.Text" Class="ml-1">@L["PurgeStatusActive"]</MudChip>
+                        }
+                        else if (activePurgeStatus == "complete")
+                        {
+                            <MudChip T="string" Color="Color.Success" Size="Size.Small" Variant="Variant.Text" Class="ml-1">@L["PurgeStatusComplete"]</MudChip>
+                        }
+                        else if (activePurgeStatus == "failed")
+                        {
+                            <MudChip T="string" Color="Color.Error" Size="Size.Small" Variant="Variant.Text" Class="ml-1">@L["PurgeStatusFailed"]</MudChip>
+                        }
+                    </MudText>
+                }
+            </div>
+            @if (activePurgeStatus == "active")
+            {
+                <MudProgressCircular Color="Color.Info" Indeterminate="true" Size="Size.Small" Class="ml-4" />
+            }
+        </MudAlert>
+    }
+
     <MudGrid>
         <MudItem xs="12" md="6">
             <MudCard Elevation="3">
@@ -92,7 +123,8 @@ else
                     <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="DeleteRoom" Class="mb-2 mr-2">@L["DeleteRoom"]</MudButton>
                     <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="DeleteAndBlockRoom" Class="mb-2 mr-2">@L["DeleteAndBlockRoom"]</MudButton>
                     <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="BlockRoom" Class="mb-2 mr-2">@L["BlockRoom"]</MudButton>
-                    <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="QuarantineMedia" Class="mb-2">@L["QuarantineMedia"]</MudButton>
+                    <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="QuarantineMedia" Class="mb-2 mr-2">@L["QuarantineMedia"]</MudButton>
+                    <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="OpenPurgeHistoryDialog" Class="mb-2">@L["PurgeHistory"]</MudButton>
                 </MudCardContent>
             </MudCard>
         </MudItem>
@@ -124,6 +156,7 @@ else
                         <MudTh>@L["Time"]</MudTh>
                         <MudTh>@L["Sender"]</MudTh>
                         <MudTh>@L["Content"]</MudTh>
+                        <MudTh>@L["Actions"]</MudTh>
                     </HeaderContent>
                     <RowTemplate>
                         <MudTd DataLabel="@L["Time"]">@context.OriginServerTs.ToString("g")</MudTd>
@@ -137,6 +170,13 @@ else
                             {
                                 <pre style="max-height: 100px; max-width: 600px; overflow: auto; font-size: 0.8em; white-space: pre-wrap; font-family: monospace; color: gray;">@context.Content</pre>
                             }
+                        </MudTd>
+                        <MudTd DataLabel="@L["Actions"]">
+                            <MudIconButton Icon="@Icons.Material.Filled.DeleteSweep" 
+                                           Color="Color.Warning" 
+                                           OnClick="@(() => OpenPurgeHistoryDialogForMessage(context.EventId))"
+                                           title="@L["PurgeHistoryUpToMessage"]" 
+                                           Size="Size.Small" />
                         </MudTd>
                     </RowTemplate>
                     <PagerContent>

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Components;
 using MudBlazor;
 using SynapseAdmin.Models.ViewModels;
 using SynapseAdmin.Interfaces;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SynapseAdmin.Components.Pages
 {
@@ -30,10 +32,23 @@ namespace SynapseAdmin.Components.Pages
         private MudTable<RoomMediaItemViewModel>? remoteMediaTable;
         private readonly CancellationTokenSource _cts = new();
 
+        private string? activePurgeId;
+        private string? activePurgeStatus;
+        private CancellationTokenSource? _pollingCts;
+
         protected override async Task OnParametersSetAsync()
         {
+            StopPolling();
+            activePurgeId = RoomService.GetActivePurgeId(RoomId);
+            activePurgeStatus = null;
+
             await LoadRoomDetails();
             await LoadMessages();
+
+            if (!string.IsNullOrEmpty(activePurgeId))
+            {
+                StartPolling();
+            }
         }
 
         private async Task LoadRoomDetails()
@@ -244,8 +259,105 @@ namespace SynapseAdmin.Components.Pages
             await DialogService.ShowAsync<MediaPreviewDialog>(media.UploadName ?? L["MediaPreview"], parameters, options);
         }
 
+        private void StopPolling()
+        {
+            _pollingCts?.Cancel();
+            _pollingCts?.Dispose();
+            _pollingCts = null;
+        }
+
+        private void StartPolling()
+        {
+            if (string.IsNullOrEmpty(activePurgeId)) return;
+            
+            _pollingCts = new CancellationTokenSource();
+            var token = _pollingCts.Token;
+
+            // Start polling as a background task
+            Task.Run(async () =>
+            {
+                try
+                {
+                    while (!token.IsCancellationRequested)
+                    {
+                        var result = await RoomService.GetPurgeHistoryStatusAsync(activePurgeId, token);
+                        if (result.Success && result.Data != null)
+                        {
+                            activePurgeStatus = result.Data.Status;
+                            await InvokeAsync(StateHasChanged);
+
+                            if (activePurgeStatus == "complete")
+                            {
+                                RoomService.ClearActivePurgeId(RoomId);
+                                activePurgeId = null;
+                                activePurgeStatus = null;
+                                Snackbar.Add(L["PurgeCompleted"], Severity.Success);
+                                await InvokeAsync(StateHasChanged);
+                                break;
+                            }
+                            else if (activePurgeStatus == "failed")
+                            {
+                                RoomService.ClearActivePurgeId(RoomId);
+                                activePurgeId = null;
+                                activePurgeStatus = null;
+                                var errMsg = !string.IsNullOrEmpty(result.Data.Error) 
+                                    ? string.Format(L["PurgeFailed"], result.Data.Error)
+                                    : string.Format(L["PurgeFailed"], L["UnknownError"]);
+                                Snackbar.Add(errMsg, Severity.Error);
+                                await InvokeAsync(StateHasChanged);
+                                break;
+                            }
+                        }
+                        
+                        await Task.Delay(5000, token);
+                    }
+                }
+                catch (TaskCanceledException)
+                {
+                    // Ignore cancellation
+                }
+                catch (Exception)
+                {
+                    // Ignore to prevent circuit crash
+                }
+            }, token);
+        }
+
+        private async Task OpenPurgeHistoryDialog()
+        {
+            await OpenPurgeHistoryDialogInternal(null, null);
+        }
+
+        private async Task OpenPurgeHistoryDialogForMessage(string eventId)
+        {
+            await OpenPurgeHistoryDialogInternal(eventId, null);
+        }
+
+        private async Task OpenPurgeHistoryDialogInternal(string? preselectedEventId, DateTimeOffset? preselectedTimestamp)
+        {
+            var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
+            var parameters = new DialogParameters
+            {
+                { "RoomId", RoomId },
+                { "PreselectedEventId", preselectedEventId },
+                { "PreselectedTimestamp", preselectedTimestamp }
+            };
+
+            var dialog = await DialogService.ShowAsync<PurgeHistoryDialog>(L["PurgeHistory"], parameters, options);
+            var result = await dialog.Result;
+
+            if (result != null && !result.Canceled && result.Data is string newPurgeId)
+            {
+                activePurgeId = newPurgeId;
+                activePurgeStatus = "active";
+                StartPolling();
+                StateHasChanged();
+            }
+        }
+
         public void Dispose()
         {
+            StopPolling();
             _cts.Cancel();
             _cts.Dispose();
         }

--- a/src/SynapseAdmin/Infrastructure/Gateways/MatrixAuthGateway.cs
+++ b/src/SynapseAdmin/Infrastructure/Gateways/MatrixAuthGateway.cs
@@ -70,6 +70,8 @@ internal class GenericMatrixGateway(AuthenticatedHomeserverGeneric homeserver) :
     public override Task BlockRoomAsync(string roomId, bool block, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     public override Task<RoomStatisticsResponse?> GetLargestRoomsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
     public override Task<SynapseAdminRoomMessagesResponse?> GetRoomMessagesAsync(string roomId, int? limit = null, string? from = null, string? dir = null, string? filter = null, string? to = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<SynapseAdminPurgeHistoryResponse?> PurgeRoomHistoryAsync(string roomId, SynapseAdminPurgeHistoryRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<SynapseAdminPurgeHistoryStatusResponse?> GetPurgeHistoryStatusAsync(string purgeId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     public override Task<SynapseAdminDestinationListResult?> GetFederationDestinationListAsync(int offset, int limit, string direction, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     public override Task ResetFederationConnectionTimeoutAsync(string destination, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     public override Task<SynapseAdminEventReportListResult?> GetEventReportListAsync(int offset, int limit, string direction, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/src/SynapseAdmin/Infrastructure/Gateways/MatrixGatewayBase.cs
+++ b/src/SynapseAdmin/Infrastructure/Gateways/MatrixGatewayBase.cs
@@ -79,6 +79,8 @@ public abstract class MatrixGatewayBase(AuthenticatedHomeserverGeneric homeserve
     public abstract Task BlockRoomAsync(string roomId, bool block, CancellationToken cancellationToken = default);
     public abstract Task<RoomStatisticsResponse?> GetLargestRoomsAsync(CancellationToken cancellationToken = default);
     public abstract Task<SynapseAdminRoomMessagesResponse?> GetRoomMessagesAsync(string roomId, int? limit = null, string? from = null, string? dir = null, string? filter = null, string? to = null, CancellationToken cancellationToken = default);
+    public abstract Task<SynapseAdminPurgeHistoryResponse?> PurgeRoomHistoryAsync(string roomId, SynapseAdminPurgeHistoryRequest request, CancellationToken cancellationToken = default);
+    public abstract Task<SynapseAdminPurgeHistoryStatusResponse?> GetPurgeHistoryStatusAsync(string purgeId, CancellationToken cancellationToken = default);
 
     // Federation
     public abstract Task<SynapseAdminDestinationListResult?> GetFederationDestinationListAsync(int offset, int limit, string direction, CancellationToken cancellationToken = default);

--- a/src/SynapseAdmin/Infrastructure/Gateways/SynapseAdminGateway.cs
+++ b/src/SynapseAdmin/Infrastructure/Gateways/SynapseAdminGateway.cs
@@ -203,6 +203,20 @@ public class SynapseAdminGateway(AuthenticatedHomeserverSynapse synapse) : Matri
         return await _synapse.ClientHttpClient.GetFromJsonAsync<SynapseAdminRoomMessagesResponse>(url, cancellationToken: cancellationToken);
     }
 
+    public override async Task<SynapseAdminPurgeHistoryResponse?> PurgeRoomHistoryAsync(string roomId, SynapseAdminPurgeHistoryRequest request, CancellationToken cancellationToken = default)
+    {
+        var url = $"/_synapse/admin/v1/purge_history/{roomId.UrlEncode()}";
+        var resp = await _synapse.ClientHttpClient.PostAsJsonAsync(url, request, cancellationToken: cancellationToken);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<SynapseAdminPurgeHistoryResponse>(cancellationToken: cancellationToken);
+    }
+
+    public override async Task<SynapseAdminPurgeHistoryStatusResponse?> GetPurgeHistoryStatusAsync(string purgeId, CancellationToken cancellationToken = default)
+    {
+        var url = $"/_synapse/admin/v1/purge_history_status/{purgeId.UrlEncode()}";
+        return await _synapse.ClientHttpClient.GetFromJsonAsync<SynapseAdminPurgeHistoryStatusResponse>(url, cancellationToken: cancellationToken);
+    }
+
     // --- Federation ---
 
     public override async Task<SynapseAdminDestinationListResult?> GetFederationDestinationListAsync(int offset, int limit, string direction, CancellationToken cancellationToken = default)

--- a/src/SynapseAdmin/Interfaces/Gateways/IMatrixGateway.cs
+++ b/src/SynapseAdmin/Interfaces/Gateways/IMatrixGateway.cs
@@ -41,6 +41,8 @@ public interface IMatrixGateway
     Task BlockRoomAsync(string roomId, bool block, CancellationToken cancellationToken = default);
     Task<RoomStatisticsResponse?> GetLargestRoomsAsync(CancellationToken cancellationToken = default);
     Task<SynapseAdminRoomMessagesResponse?> GetRoomMessagesAsync(string roomId, int? limit = null, string? from = null, string? dir = null, string? filter = null, string? to = null, CancellationToken cancellationToken = default);
+    Task<SynapseAdminPurgeHistoryResponse?> PurgeRoomHistoryAsync(string roomId, SynapseAdminPurgeHistoryRequest request, CancellationToken cancellationToken = default);
+    Task<SynapseAdminPurgeHistoryStatusResponse?> GetPurgeHistoryStatusAsync(string purgeId, CancellationToken cancellationToken = default);
 
     // --- Federation (Admin/Synapse) ---
     Task<SynapseAdminDestinationListResult?> GetFederationDestinationListAsync(int offset, int limit, string direction, CancellationToken cancellationToken = default);

--- a/src/SynapseAdmin/Interfaces/IRoomService.cs
+++ b/src/SynapseAdmin/Interfaces/IRoomService.cs
@@ -1,6 +1,8 @@
 using MudBlazor;
 using SynapseAdmin.Models;
 using SynapseAdmin.Models.ViewModels;
+using SynapseAdmin.Models.Requests;
+using SynapseAdmin.Models.Responses;
 
 namespace SynapseAdmin.Interfaces;
 
@@ -14,4 +16,9 @@ public interface IRoomService
     Task<OperationResult<List<RoomStatisticsViewModel>>> GetLargestRoomsAsync(CancellationToken token = default);
     Task<OperationResult<RoomMessagesViewModel>> GetRoomMessagesAsync(string roomId, string? from = null, int limit = 10, string dir = "f", string? filter = null, string? to = null, CancellationToken token = default);
     Task<OperationResult<List<RoomMediaItemViewModel>>> GetMediaMetadataBatchAsync(List<string> mxcUris, CancellationToken token = default);
+    Task<OperationResult<SynapseAdminPurgeHistoryResponse>> PurgeRoomHistoryAsync(string roomId, SynapseAdminPurgeHistoryRequest request, CancellationToken token = default);
+    Task<OperationResult<SynapseAdminPurgeHistoryStatusResponse>> GetPurgeHistoryStatusAsync(string purgeId, CancellationToken token = default);
+    string? GetActivePurgeId(string roomId);
+    void SetActivePurgeId(string roomId, string purgeId);
+    void ClearActivePurgeId(string roomId);
 }

--- a/src/SynapseAdmin/Models/Requests/SynapseAdminPurgeHistoryRequest.cs
+++ b/src/SynapseAdmin/Models/Requests/SynapseAdminPurgeHistoryRequest.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace SynapseAdmin.Models.Requests;
+
+public class SynapseAdminPurgeHistoryRequest
+{
+    [JsonPropertyName("delete_local_events")]
+    public bool? DeleteLocalEvents { get; set; }
+
+    [JsonPropertyName("purge_up_to_event_id")]
+    public string? PurgeUpToEventId { get; set; }
+
+    [JsonPropertyName("purge_up_to_ts")]
+    public long? PurgeUpToTs { get; set; }
+}

--- a/src/SynapseAdmin/Models/Responses/SynapseAdminPurgeHistoryResponse.cs
+++ b/src/SynapseAdmin/Models/Responses/SynapseAdminPurgeHistoryResponse.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace SynapseAdmin.Models.Responses;
+
+public class SynapseAdminPurgeHistoryResponse
+{
+    [JsonPropertyName("purge_id")]
+    public string PurgeId { get; set; } = string.Empty;
+}

--- a/src/SynapseAdmin/Models/Responses/SynapseAdminPurgeHistoryStatusResponse.cs
+++ b/src/SynapseAdmin/Models/Responses/SynapseAdminPurgeHistoryStatusResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace SynapseAdmin.Models.Responses;
+
+public class SynapseAdminPurgeHistoryStatusResponse
+{
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty; // active, complete, failed
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+}

--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -928,4 +928,73 @@
   <data name="BackgroundUpdateJobStarted" xml:space="preserve">
     <value>Hintergrundaktualisierungs-Job erfolgreich gestartet.</value>
   </data>
+  <data name="PurgeHistory" xml:space="preserve">
+    <value>Verlauf bereinigen</value>
+  </data>
+  <data name="PurgeHistoryWarning" xml:space="preserve">
+    <value>Warnung: Das Bereinigen des Raumverlaufs ist eine destruktive Operation, die historische Ereignisse dauerhaft aus der Datenbank löscht. Das Freigeben von Festplattenspeicher kann einige Minuten dauern. Während dieser Zeit können Benutzer nicht weiter zurückblättern als bis zum Bereinigungspunkt. Synapse erfordert, dass mindestens eine Nachricht im Raum verbleibt.</value>
+  </data>
+  <data name="DeleteLocalEvents" xml:space="preserve">
+    <value>Lokale Ereignisse löschen</value>
+  </data>
+  <data name="DeleteLocalEventsHelp" xml:space="preserve">
+    <value>Standardmäßig bleiben von lokalen Benutzern gesendete Ereignisse erhalten. Aktivieren Sie diese Option, um auch von lokalen Benutzern gesendete Nachrichten zu löschen.</value>
+  </data>
+  <data name="PurgeUpToDate" xml:space="preserve">
+    <value>Bis zu einem bestimmten Datum/Uhrzeit bereinigen</value>
+  </data>
+  <data name="PurgeUpToEvent" xml:space="preserve">
+    <value>Bis zu einer bestimmten Ereignis-ID (Event-ID) bereinigen</value>
+  </data>
+  <data name="SelectPurgeTarget" xml:space="preserve">
+    <value>Bereinigungspunkt auswählen</value>
+  </data>
+  <data name="SelectDate" xml:space="preserve">
+    <value>Datum auswählen</value>
+  </data>
+  <data name="SelectTime" xml:space="preserve">
+    <value>Uhrzeit auswählen</value>
+  </data>
+  <data name="PurgeHistoryUpToMessage" xml:space="preserve">
+    <value>Verlauf bis zu dieser Nachricht bereinigen</value>
+  </data>
+  <data name="PurgeInProgress" xml:space="preserve">
+    <value>Bereinigung läuft</value>
+  </data>
+  <data name="PurgeInProgressDescription" xml:space="preserve">
+    <value>Für diesen Raum ist derzeit eine Bereinigung des Verlaufs active. Alte Verlaufsereignisse werden aus der Datenbank gelöscht.</value>
+  </data>
+  <data name="PurgeStarted" xml:space="preserve">
+    <value>Bereinigung des Verlaufs erfolgreich gestartet.</value>
+  </data>
+  <data name="PurgeCompleted" xml:space="preserve">
+    <value>Bereinigung des Verlaufs erfolgreich abgeschlossen.</value>
+  </data>
+  <data name="PurgeFailed" xml:space="preserve">
+    <value>Bereinigung des Verlaufs fehlgeschlagen: {0}</value>
+  </data>
+  <data name="ErrorPurgingHistory" xml:space="preserve">
+    <value>Fehler beim Starten der Bereinigung des Raumverlaufs.</value>
+  </data>
+  <data name="ErrorFetchingPurgeStatus" xml:space="preserve">
+    <value>Fehler beim Überprüfen des Bereinigungsstatus.</value>
+  </data>
+  <data name="PurgeStatusActive" xml:space="preserve">
+    <value>Aktiv</value>
+  </data>
+  <data name="PurgeStatusComplete" xml:space="preserve">
+    <value>Abgeschlossen</value>
+  </data>
+  <data name="PurgeStatusFailed" xml:space="preserve">
+    <value>Fehlgeschlagen</value>
+  </data>
+  <data name="PurgeStatus" xml:space="preserve">
+    <value>Bereinigungsstatus</value>
+  </data>
+  <data name="PurgeUpToRequired" xml:space="preserve">
+    <value>Bereinigungspunkt ist erforderlich.</value>
+  </data>
+  <data name="InvalidDateOrTime" xml:space="preserve">
+    <value>Bitte wählen Sie ein gültiges Datum und eine gültige Uhrzeit aus.</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -928,4 +928,73 @@
   <data name="BackgroundUpdateJobStarted" xml:space="preserve">
     <value>La tâche de mise à jour en arrière-plan a démarré avec succès.</value>
   </data>
+  <data name="PurgeHistory" xml:space="preserve">
+    <value>Purger l'historique</value>
+  </data>
+  <data name="PurgeHistoryWarning" xml:space="preserve">
+    <value>Attention : Purger l'historique du salon est une opération destructive qui supprime définitivement les événements historiques de la base de données. La libération de l'espace disque peut prendre plusieurs minutes. Pendant cette période, les utilisateurs ne pourront pas remonter plus loin que le point de purge. Synapse exige de conserver au moins un message dans le salon.</value>
+  </data>
+  <data name="DeleteLocalEvents" xml:space="preserve">
+    <value>Supprimer les événements locaux</value>
+  </data>
+  <data name="DeleteLocalEventsHelp" xml:space="preserve">
+    <value>Par défaut, les événements envoyés par les utilisateurs locaux sont conservés. Activez cette option pour supprimer également les messages envoyés par les utilisateurs locaux.</value>
+  </data>
+  <data name="PurgeUpToDate" xml:space="preserve">
+    <value>Purger jusqu'à une date et heure précises</value>
+  </data>
+  <data name="PurgeUpToEvent" xml:space="preserve">
+    <value>Purger jusqu'à un ID d'événement (Event ID) spécifique</value>
+  </data>
+  <data name="SelectPurgeTarget" xml:space="preserve">
+    <value>Sélectionner le point de purge</value>
+  </data>
+  <data name="SelectDate" xml:space="preserve">
+    <value>Sélectionner la date</value>
+  </data>
+  <data name="SelectTime" xml:space="preserve">
+    <value>Sélectionner l'heure</value>
+  </data>
+  <data name="PurgeHistoryUpToMessage" xml:space="preserve">
+    <value>Purger l'historique jusqu'à ce message</value>
+  </data>
+  <data name="PurgeInProgress" xml:space="preserve">
+    <value>Purge en cours</value>
+  </data>
+  <data name="PurgeInProgressDescription" xml:space="preserve">
+    <value>Une purge d'historique est actuellement active pour ce salon. Les anciens événements d'historique sont en cours de suppression de la base de données.</value>
+  </data>
+  <data name="PurgeStarted" xml:space="preserve">
+    <value>La purge de l'historique a démarré avec succès.</value>
+  </data>
+  <data name="PurgeCompleted" xml:space="preserve">
+    <value>La purge de l'historique s'est terminée avec succès.</value>
+  </data>
+  <data name="PurgeFailed" xml:space="preserve">
+    <value>La purge de l'historique a échoué : {0}</value>
+  </data>
+  <data name="ErrorPurgingHistory" xml:space="preserve">
+    <value>Erreur lors du démarrage de la purge de l'historique du salon.</value>
+  </data>
+  <data name="ErrorFetchingPurgeStatus" xml:space="preserve">
+    <value>Erreur lors de la vérification du statut de la purge.</value>
+  </data>
+  <data name="PurgeStatusActive" xml:space="preserve">
+    <value>Active</value>
+  </data>
+  <data name="PurgeStatusComplete" xml:space="preserve">
+    <value>Terminée</value>
+  </data>
+  <data name="PurgeStatusFailed" xml:space="preserve">
+    <value>Échouée</value>
+  </data>
+  <data name="PurgeStatus" xml:space="preserve">
+    <value>Statut de la purge</value>
+  </data>
+  <data name="PurgeUpToRequired" xml:space="preserve">
+    <value>Le point de purge est requis.</value>
+  </data>
+  <data name="InvalidDateOrTime" xml:space="preserve">
+    <value>Veuillez sélectionner une date et une heure valides.</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -944,4 +944,73 @@
   <data name="BackgroundUpdateJobStarted" xml:space="preserve">
     <value>Background update job started successfully.</value>
   </data>
+  <data name="PurgeHistory" xml:space="preserve">
+    <value>Purge History</value>
+  </data>
+  <data name="PurgeHistoryWarning" xml:space="preserve">
+    <value>Warning: Purging room history is a destructive operation that permanently deletes historic events from the database. Reclaiming disk space may take several minutes. During this period, users cannot paginate further back than the purge point. Synapse requires retaining at least one message in the room.</value>
+  </data>
+  <data name="DeleteLocalEvents" xml:space="preserve">
+    <value>Delete Local Events</value>
+  </data>
+  <data name="DeleteLocalEventsHelp" xml:space="preserve">
+    <value>By default, events sent by local users are preserved. Toggle this option to delete messages sent by local users as well.</value>
+  </data>
+  <data name="PurgeUpToDate" xml:space="preserve">
+    <value>Purge up to specific Date and Time</value>
+  </data>
+  <data name="PurgeUpToEvent" xml:space="preserve">
+    <value>Purge up to specific Event ID</value>
+  </data>
+  <data name="SelectPurgeTarget" xml:space="preserve">
+    <value>Select Purge Target Point</value>
+  </data>
+  <data name="SelectDate" xml:space="preserve">
+    <value>Select Date</value>
+  </data>
+  <data name="SelectTime" xml:space="preserve">
+    <value>Select Time</value>
+  </data>
+  <data name="PurgeHistoryUpToMessage" xml:space="preserve">
+    <value>Purge history up to this message</value>
+  </data>
+  <data name="PurgeInProgress" xml:space="preserve">
+    <value>Purge In Progress</value>
+  </data>
+  <data name="PurgeInProgressDescription" xml:space="preserve">
+    <value>A history purge is currently active for this room. Old history events are being cleaned up from the database.</value>
+  </data>
+  <data name="PurgeStarted" xml:space="preserve">
+    <value>History purge started successfully.</value>
+  </data>
+  <data name="PurgeCompleted" xml:space="preserve">
+    <value>History purge completed successfully.</value>
+  </data>
+  <data name="PurgeFailed" xml:space="preserve">
+    <value>History purge failed: {0}</value>
+  </data>
+  <data name="ErrorPurgingHistory" xml:space="preserve">
+    <value>Error starting room history purge.</value>
+  </data>
+  <data name="ErrorFetchingPurgeStatus" xml:space="preserve">
+    <value>Error checking purge history status.</value>
+  </data>
+  <data name="PurgeStatusActive" xml:space="preserve">
+    <value>Active</value>
+  </data>
+  <data name="PurgeStatusComplete" xml:space="preserve">
+    <value>Complete</value>
+  </data>
+  <data name="PurgeStatusFailed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="PurgeStatus" xml:space="preserve">
+    <value>Purge Status</value>
+  </data>
+  <data name="PurgeUpToRequired" xml:space="preserve">
+    <value>Purge target point is required.</value>
+  </data>
+  <data name="InvalidDateOrTime" xml:space="preserve">
+    <value>Please select a valid date and time.</value>
+  </data>
 </root>

--- a/src/SynapseAdmin/Services/RoomService.cs
+++ b/src/SynapseAdmin/Services/RoomService.cs
@@ -9,6 +9,7 @@ using SynapseAdmin.Extensions.Mapping;
 using System.Text.Json;
 using SynapseAdmin.Interfaces.Gateways;
 using SynapseAdmin.Models.Requests;
+using SynapseAdmin.Models.Responses;
 
 namespace SynapseAdmin.Services;
 
@@ -321,6 +322,74 @@ public class RoomService(IMatrixSessionService sessionService, ILogger<RoomServi
         {
             logger.LogError(ex, "Error fetching room messages for {RoomId}", roomId.SanitizeForLogging());
             return OperationResult<RoomMessagesViewModel>.Failure(L["ErrorFetchingRoomMessages"]);
+        }
+    }
+
+    private readonly Dictionary<string, string> _activePurges = new();
+
+    public string? GetActivePurgeId(string roomId)
+    {
+        lock (_activePurges)
+        {
+            return _activePurges.TryGetValue(roomId, out var purgeId) ? purgeId : null;
+        }
+    }
+
+    public void SetActivePurgeId(string roomId, string purgeId)
+    {
+        lock (_activePurges)
+        {
+            _activePurges[roomId] = purgeId;
+        }
+    }
+
+    public void ClearActivePurgeId(string roomId)
+    {
+        lock (_activePurges)
+        {
+            _activePurges.Remove(roomId);
+        }
+    }
+
+    public async Task<OperationResult<SynapseAdminPurgeHistoryResponse>> PurgeRoomHistoryAsync(string roomId, SynapseAdminPurgeHistoryRequest request, CancellationToken token = default)
+    {
+        if (Gateway == null) return OperationResult<SynapseAdminPurgeHistoryResponse>.Failure(L["NotAuthenticated"]);
+
+        try
+        {
+            var result = await Gateway.PurgeRoomHistoryAsync(roomId, request, token);
+            if (result == null) return OperationResult<SynapseAdminPurgeHistoryResponse>.Failure(L["ErrorPurgingHistory"]);
+            return OperationResult<SynapseAdminPurgeHistoryResponse>.Ok(result, L["PurgeStarted"]);
+        }
+        catch (OperationCanceledException)
+        {
+            return OperationResult<SynapseAdminPurgeHistoryResponse>.Cancelled();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error purging history for room {RoomId}", roomId.SanitizeForLogging());
+            return OperationResult<SynapseAdminPurgeHistoryResponse>.Failure(L["ErrorPurgingHistory"]);
+        }
+    }
+
+    public async Task<OperationResult<SynapseAdminPurgeHistoryStatusResponse>> GetPurgeHistoryStatusAsync(string purgeId, CancellationToken token = default)
+    {
+        if (Gateway == null) return OperationResult<SynapseAdminPurgeHistoryStatusResponse>.Failure(L["NotAuthenticated"]);
+
+        try
+        {
+            var result = await Gateway.GetPurgeHistoryStatusAsync(purgeId, token);
+            if (result == null) return OperationResult<SynapseAdminPurgeHistoryStatusResponse>.Failure(L["ErrorFetchingPurgeStatus"]);
+            return OperationResult<SynapseAdminPurgeHistoryStatusResponse>.Ok(result);
+        }
+        catch (OperationCanceledException)
+        {
+            return OperationResult<SynapseAdminPurgeHistoryStatusResponse>.Cancelled();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting purge status for purge {PurgeId}", purgeId.SanitizeForLogging());
+            return OperationResult<SynapseAdminPurgeHistoryStatusResponse>.Failure(L["ErrorFetchingPurgeStatus"]);
         }
     }
 }


### PR DESCRIPTION
This PR implements Room History Purging on the Room Details page, allowing administrators to monitor running purges, purge history up to specific timestamps or event IDs, and toggle the deletion of local messages.
Closes #183 