### PR TITLE
fix: clean up unused localization, fix typos, and add missing translations

### DIFF
--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -58,9 +58,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Language" xml:space="preserve">
-    <value>Sprache</value>
-  </data>
   <data name="Navigation" xml:space="preserve">
     <value>Navigation</value>
   </data>
@@ -283,12 +280,6 @@
   <data name="Homeserver" xml:space="preserve">
     <value>Homeserver</value>
   </data>
-  <data name="SynapseAdminInfo" xml:space="preserve">
-    <value>Synapse Admin Info</value>
-  </data>
-  <data name="ConnectedToSynapseWithAdmin" xml:space="preserve">
-    <value>Sie sind mit einem Synapse-Homeserver mit Administratorrechten verbunden.</value>
-  </data>
   <data name="CreateToken" xml:space="preserve">
     <value>Token erstellen</value>
   </data>
@@ -462,9 +453,6 @@
   </data>
   <data name="GoToReplacementRoom" xml:space="preserve">
     <value>Gehe zum Ersatzraum</value>
-  </data>
-  <data name="Tombstone" xml:space="preserve">
-    <value>Grabstein</value>
   </data>
   <data name="EditRegistrationToken" xml:space="preserve">
     <value>Registrierungstoken bearbeiten</value>
@@ -718,14 +706,8 @@
   <data name="CreateUser" xml:space="preserve">
     <value>Benutzer erstellen</value>
   </data>
-  <data name="RegisterUser" xml:space="preserve">
-    <value>Benutzer registrieren</value>
-  </data>
   <data name="ErrorFetchingRoomMessages" xml:space="preserve">
     <value>Fehler beim Abrufen der Raumnachrichten.</value>
-  </data>
-  <data name="RoomMessages" xml:space="preserve">
-    <value>Raumnachrichten</value>
   </data>
   <data name="EventId" xml:space="preserve">
     <value>Ereignis-ID</value>
@@ -910,12 +892,6 @@
   <data name="Trigger" xml:space="preserve">
     <value>Auslösen</value>
   </data>
-  <data name="Yes" xml:space="preserve">
-    <value>Ja</value>
-  </data>
-  <data name="No" xml:space="preserve">
-    <value>Nein</value>
-  </data>
   <data name="ErrorFetchingBackgroundUpdatesStatus" xml:space="preserve">
     <value>Fehler beim Abrufen des Hintergrundaktualisierungsstatus.</value>
   </data>
@@ -945,9 +921,6 @@
   </data>
   <data name="PurgeUpToEvent" xml:space="preserve">
     <value>Bis zu einer bestimmten Ereignis-ID (Event-ID) bereinigen</value>
-  </data>
-  <data name="SelectPurgeTarget" xml:space="preserve">
-    <value>Bereinigungspunkt auswählen</value>
   </data>
   <data name="SelectDate" xml:space="preserve">
     <value>Datum auswählen</value>
@@ -1071,5 +1044,32 @@
   </data>
   <data name="MustStartWithAt" xml:space="preserve">
     <value>Muss mit @ beginnen</value>
+  </data>
+  <data name="AppserviceId" xml:space="preserve">
+    <value>Appservice-ID</value>
+  </data>
+  <data name="ConsentSent" xml:space="preserve">
+    <value>Einwilligung gesendet</value>
+  </data>
+  <data name="ConsentVersion" xml:space="preserve">
+    <value>Einwilligungsversion</value>
+  </data>
+  <data name="RoomType" xml:space="preserve">
+    <value>Raumtyp</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Schließen</value>
+  </data>
+  <data name="ErrorDeletingMedia" xml:space="preserve">
+    <value>Fehler beim Löschen des Mediums.</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Laden...</value>
+  </data>
+  <data name="MediaMaintenanceDescription" xml:space="preserve">
+    <value>Führen Sie erweiterte Wartungsarbeiten am Medien-Repository durch, leeren Sie Remote-Caches und verwalten Sie lokale Medien-Assets.</value>
+  </data>
+  <data name="UnknownError" xml:space="preserve">
+    <value>Unbekannter Fehler</value>
   </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -58,9 +58,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Language" xml:space="preserve">
-    <value>Langue</value>
-  </data>
   <data name="Navigation" xml:space="preserve">
     <value>Navigation</value>
   </data>
@@ -283,12 +280,6 @@
   <data name="Homeserver" xml:space="preserve">
     <value>Serveur domestique</value>
   </data>
-  <data name="SynapseAdminInfo" xml:space="preserve">
-    <value>Infos administration Synapse</value>
-  </data>
-  <data name="ConnectedToSynapseWithAdmin" xml:space="preserve">
-    <value>Vous êtes connecté à un serveur Synapse avec des privilèges d'administrateur.</value>
-  </data>
   <data name="CreateToken" xml:space="preserve">
     <value>Créer un jeton</value>
   </data>
@@ -462,9 +453,6 @@
   </data>
   <data name="GoToReplacementRoom" xml:space="preserve">
     <value>Aller au salon de remplacement</value>
-  </data>
-  <data name="Tombstone" xml:space="preserve">
-    <value>Tombe</value>
   </data>
   <data name="EditRegistrationToken" xml:space="preserve">
     <value>Modifier le jeton d'enregistrement</value>
@@ -718,14 +706,8 @@
   <data name="CreateUser" xml:space="preserve">
     <value>Créer un utilisateur</value>
   </data>
-  <data name="RegisterUser" xml:space="preserve">
-    <value>Enregistrer l'utilisateur</value>
-  </data>
   <data name="ErrorFetchingRoomMessages" xml:space="preserve">
     <value>Erreur lors de la récupération des messages de la salle.</value>
-  </data>
-  <data name="RoomMessages" xml:space="preserve">
-    <value>Messages de la salle</value>
   </data>
   <data name="EventId" xml:space="preserve">
     <value>ID de l'événement</value>
@@ -910,12 +892,6 @@
   <data name="Trigger" xml:space="preserve">
     <value>Déclencher</value>
   </data>
-  <data name="Yes" xml:space="preserve">
-    <value>Oui</value>
-  </data>
-  <data name="No" xml:space="preserve">
-    <value>Non</value>
-  </data>
   <data name="ErrorFetchingBackgroundUpdatesStatus" xml:space="preserve">
     <value>Erreur lors de la récupération du statut des mises à jour en arrière-plan.</value>
   </data>
@@ -945,9 +921,6 @@
   </data>
   <data name="PurgeUpToEvent" xml:space="preserve">
     <value>Purger jusqu'à un ID d'événement (Event ID) spécifique</value>
-  </data>
-  <data name="SelectPurgeTarget" xml:space="preserve">
-    <value>Sélectionner le point de purge</value>
   </data>
   <data name="SelectDate" xml:space="preserve">
     <value>Sélectionner la date</value>
@@ -1071,5 +1044,32 @@
   </data>
   <data name="MustStartWithAt" xml:space="preserve">
     <value>Doit commencer par @</value>
+  </data>
+  <data name="AppserviceId" xml:space="preserve">
+    <value>ID Appservice</value>
+  </data>
+  <data name="ConsentSent" xml:space="preserve">
+    <value>Consentement envoyé</value>
+  </data>
+  <data name="ConsentVersion" xml:space="preserve">
+    <value>Version du consentement</value>
+  </data>
+  <data name="RoomType" xml:space="preserve">
+    <value>Type de salon</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
+  <data name="ErrorDeletingMedia" xml:space="preserve">
+    <value>Erreur lors de la suppression du média.</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Chargement...</value>
+  </data>
+  <data name="MediaMaintenanceDescription" xml:space="preserve">
+    <value>Effectuer la maintenance avancée du dépôt de médias, purger les caches distants et gérer les fichiers médias locaux.</value>
+  </data>
+  <data name="UnknownError" xml:space="preserve">
+    <value>Erreur inconnue</value>
   </data>
 </root>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -58,9 +58,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Language" xml:space="preserve">
-    <value>Language</value>
-  </data>
   <data name="Navigation" xml:space="preserve">
     <value>Navigation</value>
   </data>
@@ -109,15 +106,9 @@
   <data name="CreateUser" xml:space="preserve">
     <value>Create User</value>
   </data>
-  <data name="RegisterUser" xml:space="preserve">
-    <value>Register User</value>
-  </data>
 
   <data name="ErrorFetchingRoomMessages" xml:space="preserve">
     <value>Error fetching room messages.</value>
-  </data>
-  <data name="RoomMessages" xml:space="preserve">
-    <value>Room Messages</value>
   </data>
   <data name="Messages" xml:space="preserve">
     <value>Messages</value>
@@ -320,12 +311,6 @@
   <data name="Homeserver" xml:space="preserve">
     <value>Homeserver</value>
   </data>
-  <data name="SynapseAdminInfo" xml:space="preserve">
-    <value>Synapse Admin Info</value>
-  </data>
-  <data name="ConnectedToSynapseWithAdmin" xml:space="preserve">
-    <value>You are connected to a Synapse homeserver with admin privileges.</value>
-  </data>
   <data name="CreateToken" xml:space="preserve">
     <value>Create Token</value>
   </data>
@@ -499,9 +484,6 @@
   </data>
   <data name="GoToReplacementRoom" xml:space="preserve">
     <value>Go to Replacement Room</value>
-  </data>
-  <data name="Tombstone" xml:space="preserve">
-    <value>Tombstone</value>
   </data>
   <data name="EditRegistrationToken" xml:space="preserve">
     <value>Edit Registration Token</value>
@@ -827,9 +809,6 @@
   <data name="ConsentSent" xml:space="preserve">
     <value>Consent Sent</value>
   </data>
-  <data name="Suspended" xml:space="preserve">
-    <value>Suspended</value>
-  </data>
   <data name="HomeserverUrlRequired" xml:space="preserve">
     <value>Homeserver URL is required!</value>
   </data>
@@ -926,12 +905,6 @@
   <data name="Trigger" xml:space="preserve">
     <value>Trigger</value>
   </data>
-  <data name="Yes" xml:space="preserve">
-    <value>Yes</value>
-  </data>
-  <data name="No" xml:space="preserve">
-    <value>No</value>
-  </data>
   <data name="ErrorFetchingBackgroundUpdatesStatus" xml:space="preserve">
     <value>Error fetching background updates status.</value>
   </data>
@@ -961,9 +934,6 @@
   </data>
   <data name="PurgeUpToEvent" xml:space="preserve">
     <value>Purge up to specific Event ID</value>
-  </data>
-  <data name="SelectPurgeTarget" xml:space="preserve">
-    <value>Select Purge Target Point</value>
   </data>
   <data name="SelectDate" xml:space="preserve">
     <value>Select Date</value>
@@ -1087,5 +1057,20 @@
   </data>
   <data name="MustStartWithAt" xml:space="preserve">
     <value>Must start with @</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="ErrorDeletingMedia" xml:space="preserve">
+    <value>Error deleting media.</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Loading...</value>
+  </data>
+  <data name="MediaMaintenanceDescription" xml:space="preserve">
+    <value>Perform advanced media repository maintenance, clean up remote caches, and manage local media assets.</value>
+  </data>
+  <data name="UnknownError" xml:space="preserve">
+    <value>Unknown error</value>
   </data>
 </root>

--- a/src/SynapseAdmin/Services/RoomService.cs
+++ b/src/SynapseAdmin/Services/RoomService.cs
@@ -214,7 +214,7 @@ public class RoomService(IMatrixSessionService sessionService, ILogger<RoomServi
         catch (Exception ex)
         {
             logger.LogError(ex, "Error blocking/unblocking room {RoomId}", roomId.SanitizeForLogging());
-            return OperationResult.Failure(block ? L["ErrorBlockingRoom"] : L["ErrorUnblockedSuccessfully"]);
+            return OperationResult.Failure(block ? L["ErrorBlockingRoom"] : L["ErrorUnblockingRoom"]);
         }
     }
 


### PR DESCRIPTION
This PR cleans up 10 unused localization keys, fixes a code typo in RoomService.cs that was referencing a non-existent key, and adds 9 missing/translated keys to the German and French resource files.