### PR TITLE
fix: restore missing resx closing tags after merge conflict

### DIFF
--- a/src/SynapseAdmin/Resources/SharedResources.de.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.de.resx
@@ -1077,6 +1077,7 @@
   </data>
   <data name="MatchingUsersCount" xml:space="preserve">
     <value>{0} übereinstimmende Benutzer gefunden</value>
+  </data>
   <data name="SearchNameOrRoomId" xml:space="preserve">
     <value>Name oder Raum-ID suchen</value>
   </data>

--- a/src/SynapseAdmin/Resources/SharedResources.fr.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.fr.resx
@@ -1077,6 +1077,7 @@
   </data>
   <data name="MatchingUsersCount" xml:space="preserve">
     <value>{0} utilisateurs correspondants trouvés</value>
+  </data>
   <data name="SearchNameOrRoomId" xml:space="preserve">
     <value>Rechercher par nom ou ID de salon</value>
   </data>

--- a/src/SynapseAdmin/Resources/SharedResources.resx
+++ b/src/SynapseAdmin/Resources/SharedResources.resx
@@ -1078,6 +1078,7 @@
   </data>
   <data name="MatchingUsersCount" xml:space="preserve">
     <value>Found {0} matching users</value>
+  </data>
   <data name="SearchNameOrRoomId" xml:space="preserve">
     <value>Search Name or Room ID</value>
   </data>


### PR DESCRIPTION
Fixes the invalid ResX XML syntax error introduced during git merge.