### PR TITLE
fix: relax user creation MXID regex and register field validation in dialog

### DIFF
--- a/reviews/2026-05-30_15-46-33_review.md
+++ b/reviews/2026-05-30_15-46-33_review.md
@@ -1,0 +1,95 @@
+# 🤖 Gemini CLI Code Review Report
+
+## 📋 Metadata
+
+* **Date:** 2026-05-30 15:46:33  
+* **Reviewed Files/Modules:** All C# (`.cs`) and Razor (`.razor`) files in `src/SynapseAdmin/` (excluding submodules)  
+* **Main Purpose of Code:** Administering Synapse Matrix homeservers via a .NET 10 Blazor Server Web App with a modern MudBlazor UI.  
+* **Review Status:** Pass (with minor bugs and validation issues to address)
+
+## 🚨 1. Security & Vulnerabilities
+
+*Focus: Hardcoded secrets, injection risks (SQL, XSS, Command), path traversal, insecure dependencies, authorization bypass.*
+
+**Issues Found:**
+* **[docker-compose.yml](file:///home/benjamin/source/SynapseAdmin.NET/docker-compose.yml):** Contains a default fallback value for `DP_PASSPHRASE=your-secure-passphrase-here` (line 12). While commented with a warning, users deploying this in production without modifying the passphrase will have insecure encryption-at-rest for session data.
+
+**Recommended Fixes:**
+* Remove the default passphrase from the compose file and instead document in the README that the application will refuse to start or log a critical error if `DP_PASSPHRASE` is missing or set to the default value.
+
+---
+
+## 🐛 2. Bugs & Logic Errors
+
+*Focus: Edge cases, Null-Reference risks, race conditions, off-by-one errors, infinite loops, incorrect async/await usage.*
+
+**Issues Found:**
+* **[UserCreateViewModel.cs](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Models/ViewModels/UserCreateViewModel.cs#L9):** The `[RegularExpression]` validation attribute for `UserId` (`^@[a-z0-9._=\-/]+:[a-z0-9.-]+\.[a-z]{2,}$`) expects a domain name ending with a dot and a 2+ character TLD. This will fail for local homeservers (e.g., `@user:localhost`, `@user:synapse`), IP address based homeservers (e.g., `@user:127.0.0.1`), or servers specifying ports (e.g., `@user:localhost:8008`).
+* **[UserCreateDialog.razor](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor#L10-L12):** The `MudTextField` for `UserId` is not bound using `For="@(() => model.UserId)"`, meaning `MudForm` does not evaluate the DataAnnotations `[RegularExpression]` attribute on the viewModel. The `UserService` also skips validation, meaning the validation regex on `UserCreateViewModel` is dead code and never executed.
+* **[PurgeHistoryDialog.razor.cs](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Components/Pages/PurgeHistoryDialog.razor.cs#L65-L66) & [RegistrationTokenDialog.razor.cs](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Components/Pages/RegistrationTokenDialog.razor.cs#L57):** Standard Blazor Server executes timezone offsets and Date/Time conversions on the server using `TimeZoneInfo.Local` or local conversion. If the client browser is in a different timezone than the server, selected local dates will be parsed under the server's local timezone rather than the client's.
+
+**Recommended Fixes:**
+* Relax the `UserId` regular expression in [UserCreateViewModel.cs](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Models/ViewModels/UserCreateViewModel.cs) to match the Matrix specification (allowing local names, ports, and domains without standard TLDs), e.g.:
+  `^@[a-z0-9._=\-/]+:[a-zA-Z0-9.-]+(?::\d+)?$`
+* Add `For="@(() => model.UserId)"` to the `MudTextField` in [UserCreateDialog.razor](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor) to ensure input fields are validated using the ViewModel attributes.
+* Query the user's local timezone offset via JS Interop during session initialization and use that offset for timezone-dependent calculations (like scheduling purges or tokens) rather than falling back to `TimeZoneInfo.Local`.
+
+---
+
+## ⚡ 3. Performance & Efficiency
+
+*Focus: Inefficient algorithms (Big-O), memory leaks, unnecessary API calls, synchronous blocking in async code, excessive rendering in Blazor.*
+
+**Observations:**
+* Concurrency in services is well designed. For instance, [UserService.cs](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Services/UserService.cs#L53-L60) and [RoomService.cs](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Services/RoomService.cs#L56-L65) utilize `Task.WhenAll` to concurrently query media metadata and memberships, avoiding sequential await bottlenecks.
+* Blazor Server UI lists (such as `Rooms.razor` and `Users.razor`) utilize MudBlazor's server-side loading pattern (`ServerReload`), which correctly loads only the currently visible page of data.
+
+**Optimization Suggestions:**
+* No major performance bottlenecks identified.
+
+---
+
+## 🏗️ 4. Code Quality & Architecture
+
+*Focus: SOLID principles, DRY, readability, naming conventions, overly large functions/classes, correct use of Blazor code-behind pattern.*
+
+**Assessment & Remarks:**
+* **Readability:** Excellent. The codebase is clean, well-structured, and easy to follow.
+* **Modularity:** Highly modular. Strong decoupling of the presentation layer from backend protocol concerns using N-Tier Architecture and ViewModels.
+* **Framework Conventions:**
+  * Blazor code-behind pattern (`.razor.cs`) is strictly followed for all interactive pages and dialogs.
+  * Integration with MudBlazor components is used consistently.
+  * Decoupling from the `LibMatrix` SDK is maintained using `IMatrixGateway` and `IMatrixAuthGateway` interfaces.
+  * Conditionally showing features is properly managed via capability checks (`SupportsAdminApi`).
+  * `RoomService` is configured as a scoped service. However, it holds `_activePurges` in a private dictionary with thread safety locks (`lock`). Since scoped services are created per circuit, this state will not persist across reloads or be shared between users. If it was meant to be global, the tracking dictionary should be moved to a singleton state service.
+
+---
+
+## 🛡️ 5. Error Handling & Logging
+
+*Focus: Are exceptions caught cleanly? Are there fallbacks? Are error messages meaningful without leaking sensitive data? Is Snackbar/Logging used properly?*
+
+**Remarks:**
+* Error handling is extremely robust. Services strictly catch exceptions, log the exact stack traces on the server using `ILogger`, and return localized user-friendly errors via `OperationResult`.
+* Silent cancellation is fully implemented: services catch `OperationCanceledException` and return `OperationResult.Cancelled()` (Severity.Normal), and UI components check for `Severity.Normal` to suppress error alerts during rapid reloads.
+* Parameters logged to Serilog are sanitized using `.SanitizeForLogging()` to prevent log injection.
+
+---
+
+## 🎯 6. Conclusion & Action Items
+
+*Summary of the most important to-dos prioritized by importance.*
+
+### 🔴 High Priority (Blocker)
+* None.
+
+### 🟡 Medium Priority (Bugs & Refactoring)
+* [ ] Fix the overly restrictive `UserId` regular expression in [UserCreateViewModel.cs](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Models/ViewModels/UserCreateViewModel.cs) to allow local addresses, IPs, and port numbers.
+* [ ] Add `For="@(() => model.UserId)"` in [UserCreateDialog.razor](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor) to enforce the validation.
+* [ ] Warn or crash if the default `DP_PASSPHRASE` value is used in production.
+
+### 🟢 Low Priority (Nitpicks & Style)
+* [ ] Fix timezone discrepancies in [PurgeHistoryDialog.razor.cs](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Components/Pages/PurgeHistoryDialog.razor.cs) and [RegistrationTokenDialog.razor.cs](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Components/Pages/RegistrationTokenDialog.razor.cs) by retrieving the browser's timezone offset via JS interop rather than using the server's timezone.
+* [ ] Refactor `RoomService`'s active purge tracking to a singleton state service if tracking needs to survive reloads or be shared.
+
+*Generated by Gemini CLI*

--- a/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor
+++ b/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor
@@ -9,10 +9,12 @@
         <MudForm @ref="form" @bind-IsValid="@success">
             <MudTextField T="string" Label="@L["UserId"]" @bind-Value="model.UserId" Required="true" 
                           RequiredError="@L["UserIdRequired"]" HelperText="@L["UserIdFormatHelper"]" 
+                          For="@(() => model.UserId)"
                           Validation="@(new Func<string, string?>(v => !string.IsNullOrEmpty(v) && !v.StartsWith("@") ? L["MustStartWithAt"].Value : null))" />
             
             <MudTextField T="string" Label="@L["Password"]" @bind-Value="model.Password" Required="true" 
-                          InputType="InputType.Password" RequiredError="@L["PasswordRequired"]" />
+                          InputType="InputType.Password" RequiredError="@L["PasswordRequired"]"
+                          For="@(() => model.Password)" />
             
             <MudTextField T="string" Label="@L["DisplayName"]" @bind-Value="model.DisplayName" />
             

--- a/src/SynapseAdmin/Models/ViewModels/UserCreateViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/UserCreateViewModel.cs
@@ -6,7 +6,7 @@ namespace SynapseAdmin.Models.ViewModels;
 public class UserCreateViewModel
 {
     [Required(ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = "UserIdRequired")]
-    [RegularExpression(@"^@[a-z0-9._=\-/]+:[a-z0-9.-]+\.[a-z]{2,}$", ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = "InvalidMxidFormat")]
+    [RegularExpression(@"^@[a-z0-9._=\-/]+:[a-zA-Z0-9.-]+(?::\d+)?$", ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = "InvalidMxidFormat")]
     public string UserId { get; set; } = string.Empty;
 
     [Required(ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = "PasswordRequired")]


### PR DESCRIPTION
This PR resolves the medium priority issues 1 and 2 from the latest code review:

1. Relaxes the regular expression in [UserCreateViewModel.cs](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Models/ViewModels/UserCreateViewModel.cs) to allow user creation on local servers, IP addresses, and custom ports.
2. Registers `For` attributes on the [UserCreateDialog.razor](file:///home/benjamin/source/SynapseAdmin.NET/src/SynapseAdmin/Components/Pages/UserCreateDialog.razor) textfields so MudBlazor correctly evaluates and shows the validation messages for DataAnnotations.