### PR TITLE
feat: remove delete button for remote media

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -370,11 +370,6 @@ else
                                                        OnClick="@(() => UnquarantineSingleMedia(context.MediaId))"
                                                        title="@L["Unquarantine"]" />
                                     }
-                                    
-                                    <MudIconButton Icon="@Icons.Material.Filled.Delete" 
-                                                   Color="Color.Error" 
-                                                   OnClick="@(() => DeleteSingleMedia(context.MediaId))"
-                                                   title="@L["Delete"]" />
                                 </div>
                             </MudTd>
                         </RowTemplate>


### PR DESCRIPTION
Removes the delete button from the remote media list in the media tab since Synapse does not support deleting individual remote media files.