### PR TITLE
feat: enrich room members list with avatar and display name

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -213,14 +213,24 @@ else
                         <MudText Typo="Typo.body2">@(string.IsNullOrEmpty(context.DisplayName) ? L["NoName"] : context.DisplayName)</MudText>
                     </MudTd>
                     <MudTd DataLabel="@L["UserId"]">
-                        <MudLink Href="@($"/users/{Uri.EscapeDataString(context.UserId)}")" Underline="Underline.Hover">@context.UserId</MudLink>
+                        @if (IsLocalUser(context.UserId))
+                        {
+                            <MudLink Href="@($"/users/{Uri.EscapeDataString(context.UserId)}")" Underline="Underline.Hover">@context.UserId</MudLink>
+                        }
+                        else
+                        {
+                            <MudText Typo="Typo.body2">@context.UserId</MudText>
+                        }
                     </MudTd>
                     <MudTd DataLabel="@L["Actions"]" Style="text-align: right;">
-                        <MudIconButton Icon="@Icons.Material.Filled.Person" 
-                                       Color="Color.Primary" 
-                                       Href="@($"/users/{Uri.EscapeDataString(context.UserId)}")"
-                                       title="@L["UserDetails"]" 
-                                       Size="Size.Small" />
+                        @if (IsLocalUser(context.UserId))
+                        {
+                            <MudIconButton Icon="@Icons.Material.Filled.Person" 
+                                           Color="Color.Primary" 
+                                           Href="@($"/users/{Uri.EscapeDataString(context.UserId)}")"
+                                           title="@L["UserDetails"]" 
+                                           Size="Size.Small" />
+                        }
                     </MudTd>
                 </RowTemplate>
                 <PagerContent>

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -187,12 +187,41 @@ else
         </MudTabPanel>
 
         <MudTabPanel Text="@L["Members"]" Icon="@Icons.Material.Filled.People">
-            <MudTable Items="room.Members" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0">
+            <MudTable Items="room.Members" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Dense="true" RowsPerPage="10">
                 <HeaderContent>
+                    <MudTh Style="width: 50px;"></MudTh>
+                    <MudTh>@L["DisplayName"]</MudTh>
                     <MudTh>@L["UserId"]</MudTh>
+                    <MudTh Style="width: 100px; text-align: right;">@L["Actions"]</MudTh>
                 </HeaderContent>
                 <RowTemplate>
-                    <MudTd DataLabel="@L["UserId"]">@context</MudTd>
+                    <MudTd>
+                        @if (!string.IsNullOrEmpty(context.AvatarUrl))
+                        {
+                            <MudAvatar Size="Size.Small">
+                                <MudImage Src="@(context.AvatarUrl.StartsWith("mxc://") ? $"/Media/Avatar?mxc={Uri.EscapeDataString(context.AvatarUrl)}" : context.AvatarUrl)" />
+                            </MudAvatar>
+                        }
+                        else
+                        {
+                            <MudAvatar Color="Color.Primary" Size="Size.Small">
+                                @(context.DisplayName?.FirstOrDefault() ?? context.UserId.FirstOrDefault())
+                            </MudAvatar>
+                        }
+                    </MudTd>
+                    <MudTd DataLabel="@L["DisplayName"]">
+                        <MudText Typo="Typo.body2">@(string.IsNullOrEmpty(context.DisplayName) ? L["NoName"] : context.DisplayName)</MudText>
+                    </MudTd>
+                    <MudTd DataLabel="@L["UserId"]">
+                        <MudLink Href="@($"/users/{Uri.EscapeDataString(context.UserId)}")" Underline="Underline.Hover">@context.UserId</MudLink>
+                    </MudTd>
+                    <MudTd DataLabel="@L["Actions"]" Style="text-align: right;">
+                        <MudIconButton Icon="@Icons.Material.Filled.Person" 
+                                       Color="Color.Primary" 
+                                       Href="@($"/users/{Uri.EscapeDataString(context.UserId)}")"
+                                       title="@L["UserDetails"]" 
+                                       Size="Size.Small" />
+                    </MudTd>
                 </RowTemplate>
                 <PagerContent>
                     <MudTablePager />

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
@@ -254,6 +254,14 @@ namespace SynapseAdmin.Components.Pages
             }
         }
 
+        private bool IsLocalUser(string userId)
+        {
+            if (string.IsNullOrEmpty(userId)) return false;
+            var serverName = MatrixSession.Gateway?.ServerName;
+            if (string.IsNullOrEmpty(serverName)) return false;
+            return userId.EndsWith($":{serverName}", StringComparison.OrdinalIgnoreCase);
+        }
+
         private bool IsPreviewable(string? mimeType)
         {
             if (string.IsNullOrEmpty(mimeType))

--- a/src/SynapseAdmin/Models/ViewModels/RoomDetailViewModel.cs
+++ b/src/SynapseAdmin/Models/ViewModels/RoomDetailViewModel.cs
@@ -23,9 +23,17 @@ public class RoomDetailViewModel
     public bool IsTombstoned { get; set; }
     public string? ReplacementRoom { get; set; }
     
-    public List<string> Members { get; set; } = [];
+    public List<RoomMemberViewModel> Members { get; set; } = [];
     public List<RoomStateEventViewModel> StateEvents { get; set; } = [];
     public RoomMediaViewModel? Media { get; set; }
+}
+
+public class RoomMemberViewModel
+{
+    public string UserId { get; set; } = string.Empty;
+    public string? DisplayName { get; set; }
+    public string? AvatarUrl { get; set; }
+    public string? Membership { get; set; }
 }
 
 public class RoomStateEventViewModel

--- a/src/SynapseAdmin/Services/RoomService.cs
+++ b/src/SynapseAdmin/Services/RoomService.cs
@@ -78,7 +78,34 @@ public class RoomService(IMatrixSessionService sessionService, ILogger<RoomServi
                     }
                 }
             }
-            vm.Members = members?.Members ?? [];
+            var memberStateEvents = stateEvents?.Events
+                .Where(e => e.Type == "m.room.member" && !string.IsNullOrEmpty(e.StateKey))
+                .GroupBy(e => e.StateKey!)
+                .ToDictionary(g => g.Key, g => g.First());
+
+            vm.Members = members?.Members.Select(userId =>
+            {
+                var memberVm = new RoomMemberViewModel { UserId = userId };
+                if (memberStateEvents != null && memberStateEvents.TryGetValue(userId, out var memberEvent))
+                {
+                    if (memberEvent.RawContent != null)
+                    {
+                        if (memberEvent.RawContent.TryGetPropertyValue("displayname", out var dnNode))
+                        {
+                            memberVm.DisplayName = dnNode?.GetValue<string>();
+                        }
+                        if (memberEvent.RawContent.TryGetPropertyValue("avatar_url", out var avNode))
+                        {
+                            memberVm.AvatarUrl = avNode?.GetValue<string>();
+                        }
+                        if (memberEvent.RawContent.TryGetPropertyValue("membership", out var msNode))
+                        {
+                            memberVm.Membership = msNode?.GetValue<string>();
+                        }
+                    }
+                }
+                return memberVm;
+            }).ToList() ?? [];
             vm.StateEvents = stateEvents?.Events.Select(e => new RoomStateEventViewModel
             {
                 Type = e.Type,


### PR DESCRIPTION
Enriches the room members list in the members tab with user display names, avatars, and direct links to user details, parsed from the m.room.member room state events.