### PR TITLE
fix: disable build provenance to remove unknown platform

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -57,6 +57,7 @@ jobs:
           context: .
           file: src/SynapseAdmin/Dockerfile
           platforms: linux/amd64,linux/arm64
+          provenance: false
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Resolves #254. Adds provenance: false to build-push-action to prevent unknown/unknown platforms from appearing in registry.