### PR TITLE
fix: remove target architecture from publish to fix missing static assets

### DIFF
--- a/src/SynapseAdmin/Dockerfile
+++ b/src/SynapseAdmin/Dockerfile
@@ -1,5 +1,6 @@
 # Build Stage
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG TARGETARCH
 WORKDIR /source
 
 # Copy solution and projects
@@ -8,12 +9,12 @@ COPY src/SynapseAdmin/SynapseAdmin.csproj src/SynapseAdmin/
 COPY LibMatrix/ LibMatrix/
 
 # Restore dependencies
-RUN dotnet restore SynapseAdmin.NET.slnx
+RUN dotnet restore SynapseAdmin.NET.slnx -a $TARGETARCH
 
 # Copy everything else and build
 COPY . .
 WORKDIR /source/src/SynapseAdmin
-RUN dotnet publish -c Release -o /app
+RUN dotnet publish -c Release -o /app -a $TARGETARCH
 
 # Runtime Stage
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime

--- a/src/SynapseAdmin/Dockerfile
+++ b/src/SynapseAdmin/Dockerfile
@@ -1,6 +1,5 @@
 # Build Stage
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
-ARG TARGETARCH
 WORKDIR /source
 
 # Copy solution and projects
@@ -9,12 +8,12 @@ COPY src/SynapseAdmin/SynapseAdmin.csproj src/SynapseAdmin/
 COPY LibMatrix/ LibMatrix/
 
 # Restore dependencies
-RUN dotnet restore SynapseAdmin.NET.slnx -a $TARGETARCH
+RUN dotnet restore SynapseAdmin.NET.slnx
 
 # Copy everything else and build
 COPY . .
 WORKDIR /source/src/SynapseAdmin
-RUN dotnet publish -c Release -o /app -a $TARGETARCH --no-restore
+RUN dotnet publish -c Release -o /app
 
 # Runtime Stage
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime


### PR DESCRIPTION
Resolves #256. Simplify Dockerfile by compiling architecture-neutral MSIL assemblies, ensuring Blazor static web assets (_framework/blazor.web.js) are generated correctly.