### PR TITLE
feat: add sorting to room members tab

### DIFF
--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -187,7 +187,10 @@ else
         </MudTabPanel>
 
         <MudTabPanel Text="@L["Members"]" Icon="@Icons.Material.Filled.People">
-            <MudTable T="RoomMemberViewModel" Items="room.Members" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Dense="true" RowsPerPage="10">
+            <MudToolBar Dense="true" Class="px-2 mb-2">
+                <MudTextField T="string" Value="@_searchTerm" ValueChanged="@OnSearchChanged" Placeholder="@L["SearchUserIdOrDisplayName"]" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" Clearable="true" Immediate="true" DebounceInterval="300" Style="max-width: 300px;" Class="mt-0" Margin="Margin.Dense" />
+            </MudToolBar>
+            <MudTable T="RoomMemberViewModel" Items="room.Members" Filter="new Func<RoomMemberViewModel, bool>(FilterFunc)" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Dense="true" RowsPerPage="10">
                 <HeaderContent>
                     <MudTh Style="width: 50px;"></MudTh>
                     <MudTh><MudTableSortLabel SortBy="new Func<RoomMemberViewModel, object>(x => x.DisplayName ?? string.Empty)">@L["DisplayName"]</MudTableSortLabel></MudTh>

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor
@@ -187,11 +187,11 @@ else
         </MudTabPanel>
 
         <MudTabPanel Text="@L["Members"]" Icon="@Icons.Material.Filled.People">
-            <MudTable Items="room.Members" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Dense="true" RowsPerPage="10">
+            <MudTable T="RoomMemberViewModel" Items="room.Members" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Dense="true" RowsPerPage="10">
                 <HeaderContent>
                     <MudTh Style="width: 50px;"></MudTh>
-                    <MudTh>@L["DisplayName"]</MudTh>
-                    <MudTh>@L["UserId"]</MudTh>
+                    <MudTh><MudTableSortLabel SortBy="new Func<RoomMemberViewModel, object>(x => x.DisplayName ?? string.Empty)">@L["DisplayName"]</MudTableSortLabel></MudTh>
+                    <MudTh><MudTableSortLabel SortBy="new Func<RoomMemberViewModel, object>(x => x.UserId)">@L["UserId"]</MudTableSortLabel></MudTh>
                     <MudTh Style="width: 100px; text-align: right;">@L["Actions"]</MudTh>
                 </HeaderContent>
                 <RowTemplate>

--- a/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
+++ b/src/SynapseAdmin/Components/Pages/RoomDetails.razor.cs
@@ -31,6 +31,7 @@ namespace SynapseAdmin.Components.Pages
         private MudTable<RoomMediaItemViewModel>? localMediaTable;
         private MudTable<RoomMediaItemViewModel>? remoteMediaTable;
         private readonly CancellationTokenSource _cts = new();
+        private string _searchTerm = string.Empty;
 
         private string? activePurgeId;
         private string? activePurgeStatus;
@@ -384,6 +385,22 @@ namespace SynapseAdmin.Components.Pages
                 StartPolling();
                 StateHasChanged();
             }
+        }
+
+        private void OnSearchChanged(string text)
+        {
+            _searchTerm = text;
+        }
+
+        private bool FilterFunc(RoomMemberViewModel member)
+        {
+            if (string.IsNullOrWhiteSpace(_searchTerm))
+                return true;
+            if (member.UserId?.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase) == true)
+                return true;
+            if (member.DisplayName?.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase) == true)
+                return true;
+            return false;
         }
 
         public void Dispose()


### PR DESCRIPTION
This PR adds client-side sorting for the Display Name and User ID columns on the Room Members tab.